### PR TITLE
Switch CODEOWNERS to use OMF teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,13 @@
-## Below is the MDS CODEOWNERS file, which dictates who is required for review on any given file. 
+## Below is the MDS CODEOWNERS file, which dictates who is required for review on any given file.
 
-## All MDS approvals 
-* @hunterowens @thekaveman @jfh01
+## All MDS approvals
+* @openmobilityfoundation/omf-admin
 
+## Provider Services Working Group
+/provider/* @openmobilityfoundation/provider-services-wg-maintainers
 
-## City Services Working Group Specific, also JSON Schema 
-/agency/*  @hunterowens @thekaveman @jfh01 @henrij
-/schema/*  @hunterowens @thekaveman @jfh01 @henrij
+## City Services Working Group Specific, also JSON Schema
+/agency/*  @openmobilityfoundation/city-services-wg-maintainers
 
+## schema is changed by provider and city services working group
+/schema/*  @openmobilityfoundation/provider-services-wg-maintainers @openmobilityfoundation/city-services-wg-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,10 +4,10 @@
 * @openmobilityfoundation/omf-admin
 
 ## Provider Services Working Group
-/provider/* @openmobilityfoundation/provider-services-wg-maintainers
+/provider/* @openmobilityfoundation/provider-services-wg-maintainers @openmobilityfoundation/omf-admin
 
 ## City Services Working Group Specific, also JSON Schema
-/agency/*  @openmobilityfoundation/city-services-wg-maintainers
+/agency/*  @openmobilityfoundation/city-services-wg-maintainers @openmobilityfoundation/omf-admin
 
 ## schema is changed by provider and city services working group
-/schema/*  @openmobilityfoundation/provider-services-wg-maintainers @openmobilityfoundation/city-services-wg-maintainers
+/schema/*  @openmobilityfoundation/provider-services-wg-maintainers @openmobilityfoundation/city-services-wg-maintainers @openmobilityfoundation/omf-admin


### PR DESCRIPTION
As part of the code transfer from LADOT to OMF (#386), we are switching CODEOWNERS to use OMF's GitHub Teams, rather than individually naming maintainers. This PR should be merged as part of the code transfer process.