### PR TITLE
replace URLs for move

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cities and regulators can choose how best to implement *Agency*, *Provider*, and
 ## Learn More / Get Involved / Contributing
 
 * To stay up to date on MDS releases and planning calls, please subscribe to the [MDS-Announce](https://groups.google.com/forum/#!forum/mds-announce) mailing list. 
-* You can view info about past releases and planning calls in the [wiki](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki). 
+* You can view info about past releases and planning calls in the [wiki](https://github.com/openmobilityfoundation/mobility-data-specification/wiki). 
 * To understand the contributing guidelines review the [CONTRIBUTING page.](CONTRIBUTING.md) 
 * To learn more about MDS and other related projects, including LADOT's Technology Action Plan, visit [ladot.io.](https://ladot.io/)
 
@@ -27,13 +27,13 @@ For questions about MDS please contact [ladot.innovation@lacity.org](mailto:lado
 
 ## Versions
 
-The specification will be versioned using Git tags and [semantic versioning](https://semver.org/). See prior [releases](https://github.com/CityOfLosAngeles/mobility-data-specification/releases) and the [Release Guidelines](ReleaseGuidelines.md) for more information.
+The specification will be versioned using Git tags and [semantic versioning](https://semver.org/). See prior [releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases) and the [Release Guidelines](ReleaseGuidelines.md) for more information.
 
 Information about the latest release and all releases are below. Please note, you may be viewing a development copy of the Mobility Data Specification based on the current branch. Info about the latest release and all releases is below.
 
-* [Latest Release](https://github.com/CityOfLosAngeles/mobility-data-specification/tree/master)
+* [Latest Release](https://github.com/openmobilityfoundation/mobility-data-specification/tree/master)
 
-* [All Releases](https://github.com/CityOfLosAngeles/mobility-data-specification/releases)
+* [All Releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases)
 
 ## Cities Using MDS 
 
@@ -44,7 +44,7 @@ The Mobility Data Specification is an Open Source project. Comments can be made 
 * Austin: The rules and guidelines for Austin's Micromobility Program can be found at https://austintexas.gov/micromobility.
 * Ulm: A draft of the guidelines can be found at [the city's GitHub presence](https://github.com/stadtulm/mds-zonen).
 
-[Add your City here by opening a pull request](https://github.com/CityofLosAngeles/mobility-data-specification/compare)
+[Add your City here by opening a pull request](https://github.com/openmobilityfoundation/mobility-data-specification/compare)
 
 ## Use Cases
 MDS enables cities to:

--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -246,11 +246,11 @@ The following steps **must** be followed for **every** release of MDS:
 
 1. Publish a [new Release in GitHub][mds-releases-new] for the tag you just pushed. Copy in the [release notes](ReleaseNotes.md) created earlier.
 
-1. Post a release announcement to [`mds-announce`](mailto:mds-announce@googlegroups.com), copying the [release notes](ReleaseNotes.md) created earlier and linking to the [GitHub release][mds-releases].
+1. Post a release announcement to [`mds-announce`](mailto:mds-announce@groups.openmobilityfoundation.org), copying the [release notes](ReleaseNotes.md) created earlier and linking to the [GitHub release][mds-releases].
 
     ```email
-    From:    mds-announce@googlegroups.com  
-    To:      mds-announce@googlegroups.com  
+    From:    mds-announce@groups.openmobilityfoundation.org 
+    To:      mds-announce@groups.openmobilityfoundation.org  
     Subject: MDS 1.2.3 Release  
 
     MDS 1.2.3 has been released.
@@ -260,7 +260,7 @@ The following steps **must** be followed for **every** release of MDS:
     <link to GitHub release>
     ```
 
-[mds-announce]: https://groups.google.com/forum/#!forum/mds-announce
+[mds-announce]: https://groups.google.com/a/groups.openmobilityfoundation.org/forum/#!forum/mds-announce
 [mds-dev]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev
 [mds-master]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/master
 [mds-milestones]: https://github.com/openmobilityfoundation/mobility-data-specification/milestones

--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -56,7 +56,7 @@ The sections below define the release process itself, including timeline, roles,
 
 ### Project Meetings
 * Web conference and in person work sessions will posted to the [MDS-Announce mailing list](https://groups.google.com/forum/#!forum/mds-announce). Meetings generally occur monthly.
-* The meeting organizer can use the [meeting template](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template) to prepare for project meetings. Use the [template markup code](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template/_edit) to create the next scheduled wiki meeting page before the meeting. Include the how to join the meeting and agenda details. Posting the agenda before the meeting has the added benefit that project contributors can propose agenda items.
+* The meeting organizer can use the [meeting template](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-Conference-Template) to prepare for project meetings. Use the [template markup code](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-Conference-Template/_edit) to create the next scheduled wiki meeting page before the meeting. Include the how to join the meeting and agenda details. Posting the agenda before the meeting has the added benefit that project contributors can propose agenda items.
 
 ### Goals
 
@@ -197,16 +197,16 @@ The following steps **must** be followed for **every** release of MDS:
 
     High level summary of the release.
 
-    * Specific change referencing a PR [#555](https://github.com/CityofLosAngeles/mobility-data-specification/pull/555)
+    * Specific change referencing a PR [#555](https://github.com/openmobilityfoundation/mobility-data-specification/pull/555)
 
-    * Another change summary referencing a PR [#777](https://github.com/CityofLosAngeles/mobility-data-specification/pull/777)
+    * Another change summary referencing a PR [#777](https://github.com/openmobilityfoundation/mobility-data-specification/pull/777)
     ```
 
     The description of this PR should include a link to a GitHub compare page showing the changes that will be included in the release. This URL depends on the type of release:
 
-    * For a PATCH release like 0.4.2, compare the previous version in the series to the current state of the release branch: https://github.com/CityOfLosAngeles/mobility-data-specification/compare/0.4.1...0.4.x
+    * For a PATCH release like 0.4.2, compare the previous version in the series to the current state of the release branch: https://github.com/openmobilityfoundation/mobility-data-specification/compare/0.4.1...0.4.x
 
-    * For a MINOR release like 0.5.0, compare the last release in the previous series to the current state of `dev`: https://github.com/CityOfLosAngeles/mobility-data-specification/compare/master...dev
+    * For a MINOR release like 0.5.0, compare the last release in the previous series to the current state of `dev`: https://github.com/openmobilityfoundation/mobility-data-specification/compare/master...dev
 
     In the case of a new MINOR version, allow a minimum of 24 hours for community discussion and review of the current state of the release.
 
@@ -261,13 +261,13 @@ The following steps **must** be followed for **every** release of MDS:
     ```
 
 [mds-announce]: https://groups.google.com/forum/#!forum/mds-announce
-[mds-dev]: https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev
-[mds-master]: https://github.com/CityOfLosAngeles/mobility-data-specification/tree/master
-[mds-milestones]: https://github.com/CityOfLosAngeles/mobility-data-specification/milestones
-[mds-pr]: https://github.com/CityofLosAngeles/mobility-data-specification/pulls
-[mds-pr-new]: https://github.com/CityOfLosAngeles/mobility-data-specification/compare
-[mds-releases]: https://github.com/CityOfLosAngeles/mobility-data-specification/releases
-[mds-releases-new]: https://github.com/CityOfLosAngeles/mobility-data-specification/releases/new
-[mds-schema-common]: https://github.com/CityOfLosAngeles/mobility-data-specification/blob/master/generate_schema/common.json
-[mds-tags]: https://github.com/CityOfLosAngeles/mobility-data-specification/tags
+[mds-dev]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev
+[mds-master]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/master
+[mds-milestones]: https://github.com/openmobilityfoundation/mobility-data-specification/milestones
+[mds-pr]: https://github.com/openmobilityfoundation/mobility-data-specification/pulls
+[mds-pr-new]: https://github.com/openmobilityfoundation/mobility-data-specification/compare
+[mds-releases]: https://github.com/openmobilityfoundation/mobility-data-specification/releases
+[mds-releases-new]: https://github.com/openmobilityfoundation/mobility-data-specification/releases/new
+[mds-schema-common]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/generate_schema/common.json
+[mds-tags]: https://github.com/openmobilityfoundation/mobility-data-specification/tags
 [semver]: https://semver.org/

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,27 +6,27 @@ The 0.4.0 release represents a major step forward in the Mobility Data Specifica
 
 **CHANGES**
 *_Provider_*
-* [Improved Handling of Cost Data](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/388)
-* [Allow static file storage backed API Endpoints](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/357)
-* [Cleanup Provider README](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/395)
-* [Legacy Version Header Cleanup](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/314)
-* [Internationalization of Currency data](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/379)
-* [Specify Types for Query Params](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/352)
-* [Clarify the definition of Municipal Boundary](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/369)
-* [Update Status Change JSON Schema to include Associated Trip properly](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/353)
+* [Improved Handling of Cost Data](https://github.com/openmobilityfoundation/mobility-data-specification/pull/388)
+* [Allow static file storage backed API Endpoints](https://github.com/openmobilityfoundation/mobility-data-specification/pull/357)
+* [Cleanup Provider README](https://github.com/openmobilityfoundation/mobility-data-specification/pull/395)
+* [Legacy Version Header Cleanup](https://github.com/openmobilityfoundation/mobility-data-specification/pull/314)
+* [Internationalization of Currency data](https://github.com/openmobilityfoundation/mobility-data-specification/pull/379)
+* [Specify Types for Query Params](https://github.com/openmobilityfoundation/mobility-data-specification/pull/352)
+* [Clarify the definition of Municipal Boundary](https://github.com/openmobilityfoundation/mobility-data-specification/pull/369)
+* [Update Status Change JSON Schema to include Associated Trip properly](https://github.com/openmobilityfoundation/mobility-data-specification/pull/353)
 
 *_Agency_*
-* [Add Accuracy Field for GPS Telemetry Data](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/360)
-* [String Limit to 255 Characters](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/361)
-* [Remove SLA from /telemetry](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/371)
-* [Update State Machine Diagram](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/363)
+* [Add Accuracy Field for GPS Telemetry Data](https://github.com/openmobilityfoundation/mobility-data-specification/pull/360)
+* [String Limit to 255 Characters](https://github.com/openmobilityfoundation/mobility-data-specification/pull/361)
+* [Remove SLA from /telemetry](https://github.com/openmobilityfoundation/mobility-data-specification/pull/371)
+* [Update State Machine Diagram](https://github.com/openmobilityfoundation/mobility-data-specification/pull/363)
 
 *_Misc_* 
-* [New Policy API Endpoint](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/382)
-* [Improved README for Schema Directory](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/398)
-* [Add Car Vehicle Type](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/219)
-* [Unify Error Responses between Provider / Agency](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/368)
-* [Imrovements to Release Process](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/372)
+* [New Policy API Endpoint](https://github.com/openmobilityfoundation/mobility-data-specification/pull/382)
+* [Improved README for Schema Directory](https://github.com/openmobilityfoundation/mobility-data-specification/pull/398)
+* [Add Car Vehicle Type](https://github.com/openmobilityfoundation/mobility-data-specification/pull/219)
+* [Unify Error Responses between Provider / Agency](https://github.com/openmobilityfoundation/mobility-data-specification/pull/368)
+* [Improvements to Release Process](https://github.com/openmobilityfoundation/mobility-data-specification/pull/372)
 
 ## 0.3.2 
 
@@ -37,16 +37,16 @@ This release is a series of non breaking and minor changes for provider, along w
 **CHANGES** 
 
 *_Provider_*
-* [Add an optional recorded field to provider](https://github.com/CityOfLosAngeles/mobility-data-specification/issues/307)
-* [Ordering Definitions](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/301)
-* [406 response - version negiotation](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/327)
+* [Add an optional recorded field to provider](https://github.com/openmobilityfoundation/mobility-data-specification/issues/307)
+* [Ordering Definitions](https://github.com/openmobilityfoundation/mobility-data-specification/pull/301)
+* [406 response - version negiotation](https://github.com/openmobilityfoundation/mobility-data-specification/pull/327)
 
 *_Agency_*
-[JSON Schema for Agency](https://github.com/CityOfLosAngeles/mobility-data-specification/issues/169)
+[JSON Schema for Agency](https://github.com/openmobilityfoundation/mobility-data-specification/issues/169)
 
 *_Misc_*
-[Schema Folder Cleanup](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/328)
-[Global GNSS Support](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/316)
+[Schema Folder Cleanup](https://github.com/openmobilityfoundation/mobility-data-specification/pull/328)
+[Global GNSS Support](https://github.com/openmobilityfoundation/mobility-data-specification/pull/316)
 ## 0.3.1
 
 > Released 2019-04-30
@@ -57,22 +57,22 @@ This release represents a series of non-breaking changes and clarifications for 
 
 *_Provider_*
 * MDS Schema version fix.
-* [New release process](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/264). Thanks @jfh for documenting, all for participating 
-* [Additional documentation around what is considered Breaking / Non-Breaking](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/295). Thanks @rf-
-* [OPTIONS for version negotiation](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/293). Thanks @billdirks
-* [Add Agency Drop off / pick up](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/291). Thanks @margodawes 
-* [Explicitly allow associated_trip for any event type](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/297)
+* [New release process](https://github.com/openmobilityfoundation/mobility-data-specification/pull/264). Thanks @jfh for documenting, all for participating 
+* [Additional documentation around what is considered Breaking / Non-Breaking](https://github.com/openmobilityfoundation/mobility-data-specification/pull/295). Thanks @rf-
+* [OPTIONS for version negotiation](https://github.com/openmobilityfoundation/mobility-data-specification/pull/293). Thanks @billdirks
+* [Add Agency Drop off / pick up](https://github.com/openmobilityfoundation/mobility-data-specification/pull/291). Thanks @margodawes 
+* [Explicitly allow associated_trip for any event type](https://github.com/openmobilityfoundation/mobility-data-specification/pull/297)
 
 *_Agency_*
 * Change from UUIDv4 to just UUID. Thanks @karcass
 * Change Error Messages for State Machine validation. 
 * Update Pagination Rules 
 * Add Unregistered event. 
-* [Add Event Diagram](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/258). Thanks @whereissean
-* [Removing 412 Responses](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/258)
+* [Add Event Diagram](https://github.com/openmobilityfoundation/mobility-data-specification/pull/258). Thanks @whereissean
+* [Removing 412 Responses](https://github.com/openmobilityfoundation/mobility-data-specification/pull/258)
 * Add deregister and decomissioned events. Thanks @dirkdk 
-* [Remove 5 second Telemetry requirement](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/261)
-* [Improve failure and error handling around Telemetry Data](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/290)
+* [Remove 5 second Telemetry requirement](https://github.com/openmobilityfoundation/mobility-data-specification/pull/261)
+* [Improve failure and error handling around Telemetry Data](https://github.com/openmobilityfoundation/mobility-data-specification/pull/290)
 
 ## 0.3.0 
 
@@ -114,11 +114,11 @@ Thanks to all contributors.
 
 > Released 2018-10-15
 
-This release backports two features from [`0.2.0`](https://github.com/CityOfLosAngeles/mobility-data-specification/releases/tag/0.2.0):
+This release backports two features from [`0.2.0`](https://github.com/openmobilityfoundation/mobility-data-specification/releases/tag/0.2.0):
 
-* Clarifying Location Types as GeoJSON [#94](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/94)
+* Clarifying Location Types as GeoJSON [#94](https://github.com/openmobilityfoundation/mobility-data-specification/pull/94)
 
-* Adding `electric-assist` as a propulsion type [#48](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/48)
+* Adding `electric-assist` as a propulsion type [#48](https://github.com/openmobilityfoundation/mobility-data-specification/pull/48)
 
 This makes MDS `0.1.x` series more usable for Mobility Providers.
 
@@ -128,17 +128,17 @@ This makes MDS `0.1.x` series more usable for Mobility Providers.
 
 This release includes a number of enhancements and clarifications to the [`provider`][provider] spec:
 
-* Introduce JSON Schema for Trips and Status Changes [#53](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/53)
+* Introduce JSON Schema for Trips and Status Changes [#53](https://github.com/openmobilityfoundation/mobility-data-specification/pull/53)
 
-* Clarify query params for API endpoints [#64](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/64)
+* Clarify query params for API endpoints [#64](https://github.com/openmobilityfoundation/mobility-data-specification/pull/64)
 
-* Clarify API authentication method [#81](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/81)
+* Clarify API authentication method [#81](https://github.com/openmobilityfoundation/mobility-data-specification/pull/81)
 
-* Clarify location formatting [#94](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/94)
+* Clarify location formatting [#94](https://github.com/openmobilityfoundation/mobility-data-specification/pull/94)
 
-* Clarify timestamp formatting [#93](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/93)
+* Clarify timestamp formatting [#93](https://github.com/openmobilityfoundation/mobility-data-specification/pull/93)
 
-* Clarify the `associated_trips` field in Status Changes [#96](https://github.com/CityOfLosAngeles/mobility-data-specification/pull/96)
+* Clarify the `associated_trips` field in Status Changes [#96](https://github.com/openmobilityfoundation/mobility-data-specification/pull/96)
 
 ## 0.1.0
 
@@ -148,4 +148,4 @@ This release includes a number of enhancements and clarifications to the [`provi
 
 * MDS is under active development. As such, pre-`1.0` versions may introduce breaking changes until things stabilize. Every effort will be made to ensure that any breaking change is well documented and that appropriate workarounds are suggested.
 
-[provider]: https://github.com/CityOfLosAngeles/mobility-data-specification/tree/master/provider
+[provider]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/master/provider

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/get_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/get_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, GET vehicle payload",
   "type": "object",

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, register vehicle body",
   "type": "object",

--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle_event.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_event.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle status body",
   "type": "object",

--- a/agency/post_vehicle_telemetry.json
+++ b/agency/post_vehicle_telemetry.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle telemetry body",
   "type": "object",

--- a/provider/auth.md
+++ b/provider/auth.md
@@ -36,4 +36,4 @@ If an MDS `provider` implements this auth scheme, it **MAY** choose to specify t
 
 The `/trips` and `/status_changes` endpoints may or may not require authentication, it is up to the implementing provider to decide if they want historical information available with or without authentication. 
 
-As of MDS 0.3.0, `gbfs.json` is required. The required GBFS endpoints should be made available publicly. See [#realtime-data](https://github.com/CityOfLosAngeles/mobility-data-specification/tree/master/provider#realtime-data) for more information about how to implement GBFS for dockless systems. 
+As of MDS 0.3.0, `gbfs.json` is required. The required GBFS endpoints should be made available publicly. See [#realtime-data](https://github.com/openmobilityfoundation/mobility-data-specification/tree/master/provider#realtime-data) for more information about how to implement GBFS for dockless systems. 

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/provider/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/provider/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",

--- a/schema/templates/agency/get_vehicle.json
+++ b/schema/templates/agency/get_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/get_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/get_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, GET vehicle payload",
   "type": "object",

--- a/schema/templates/agency/post_vehicle.json
+++ b/schema/templates/agency/post_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, register vehicle body",
   "type": "object",

--- a/schema/templates/agency/post_vehicle_event.json
+++ b/schema/templates/agency/post_vehicle_event.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle_event.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_event.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle status body",
   "type": "object",

--- a/schema/templates/agency/post_vehicle_telemetry.json
+++ b/schema/templates/agency/post_vehicle_telemetry.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle telemetry body",
   "type": "object",

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/provider/common.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/common.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, common definitions",
   "type": "object",

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/provider/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/provider/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",


### PR DESCRIPTION
### Explain pull request

Replace all instances in the repo of "cityoflosangeles/mobility-data-specification" with "openmobilityfoundation/mobility-data-specification" 
### Is this a breaking change


 * No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `agency`
 * `policy`
 * `provider`

### Additional context

