### PR TITLE
Rename car to carshare to match top-level spec description

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -264,11 +264,11 @@ A standard point of vehicle telemetry. References to latitude and longitude impl
 
 ### Vehicle Type
 
-| `type`    |
-| --------- |
-| `bicycle` |
-| `car`     |
-| `scooter` |
+| `type`     |
+| ---------- |
+| `bicycle`  |
+| `carshare` |
+| `scooter`  |
 
 ### Propulsion Type
 

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -25,7 +25,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
-        "car",
+        "carshare",
         "scooter"
       ]
     },

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -25,7 +25,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
-        "car",
+        "carshare",
         "scooter"
       ]
     },

--- a/provider/README.md
+++ b/provider/README.md
@@ -199,7 +199,7 @@ The list of allowed `vehicle_type` referenced below is:
 | `vehicle_type` |
 |--------------|
 | bicycle      |
-| car          |
+| carshare     |
 | scooter      |
 
 ### Propulsion Types

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -171,7 +171,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
-        "car",
+        "carshare",
         "scooter"
       ]
     },

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -202,7 +202,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
-        "car",
+        "carshare",
         "scooter"
       ]
     },

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -58,7 +58,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
-        "car",
+        "carshare",
         "scooter"
       ]
     },


### PR DESCRIPTION
### Explain pull request

In this commit https://github.com/openmobilityfoundation/mobility-data-specification/commit/f720a092397d9a12bcf346a03a6707b5e12f9f5f the top-level name of `car` was switched to `carshare`. However, I noticed that change did not seem to bubble down to the agency and provider spec level. This changes the `vehicle_types` enum to have `carshare` instead of `car`. This would be a breaking change, however I find the discontinuity between the types in the top level compared to agency and provider to be pretty strange... If this isn't intended to be a rename that goes down to the data-type level, feel free to close the PR!

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * Yes, breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `agency`
 * `policy`
 * `provider`

### Additional context

Add any other context or screenshots about the feature request here.
