### PR TITLE
Update example to use "maximum" instead of "limit"

### DIFF
--- a/policy/examples.md
+++ b/policy/examples.md
@@ -152,7 +152,7 @@ This Policy allows scooters and bikes can be in the public right-of-way for up t
         "bicycle",
         "scooter"
       ],
-      "limit": 24
+      "maximum": 24
   }]
 }
 ```


### PR DESCRIPTION
### Explain pull request

Hello, just a small PR to update the example (Idle time) as it has `limit` where it should be `maximum` to configure the rule.

### Is this a breaking change

 * No, not breaking

### Impacted Spec

 * `policy`