### PR TITLE
Syntax corrections from the OMF repo move

### DIFF
--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -55,8 +55,8 @@ The sections below define the release process itself, including timeline, roles,
 >**It is our intent to maintain a level of coordination between the technical direction of `agency` and `provider`. As such, proposed changes to either API will be reviewed to ensure they do not create unnecessary duplicative functionality, introduce confusion about which API should be used for a given purpose, or prevent the reconciliation of data between the two APIs (for example: using data from `provider` to cross-validate data received via `agency`).**
 
 ### Project Meetings
-* Web conference and in person work sessions will posted to the [MDS-Announce mailing list](https://groups.google.com/forum/#!forum/mds-announce). Meetings generally occur monthly.
-* The meeting organizer can use the [meeting template](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template) to prepare for project meetings. Use the [template markup code](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template/_edit) to create the next scheduled wiki meeting page before the meeting. Include the how to join the meeting and agenda details. Posting the agenda before the meeting has the added benefit that project contributors can propose agenda items.
+* Web conference and in person work sessions will posted to the [MDS-Announce mailing list](https://groups.google.com/a/groups.openmobilityfoundation.org/forum/#!forum/mds-announce). Meetings generally occur monthly.
+* The meeting organizer can use the [meeting template](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-Conference-Template) to prepare for project meetings. Use the [template markup code](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-Conference-Template/_edit) to create the next scheduled wiki meeting page before the meeting. Include the how to join the meeting and agenda details. Posting the agenda before the meeting has the added benefit that project contributors can propose agenda items.
 
 ### Goals
 
@@ -197,16 +197,16 @@ The following steps **must** be followed for **every** release of MDS:
 
     High level summary of the release.
 
-    * Specific change referencing a PR [#555](https://github.com/CityofLosAngeles/mobility-data-specification/pull/555)
+    * Specific change referencing a PR [#555](https://github.com/openmobilityfoundation/mobility-data-specification/pull/555)
 
-    * Another change summary referencing a PR [#777](https://github.com/CityofLosAngeles/mobility-data-specification/pull/777)
+    * Another change summary referencing a PR [#777](https://github.com/openmobilityfoundation/mobility-data-specification/pull/777)
     ```
 
     The description of this PR should include a link to a GitHub compare page showing the changes that will be included in the release. This URL depends on the type of release:
 
-    * For a PATCH release like 0.4.2, compare the previous version in the series to the current state of the release branch: https://github.com/CityOfLosAngeles/mobility-data-specification/compare/0.4.1...0.4.x
+    * For a PATCH release like 0.4.2, compare the previous version in the series to the current state of the release branch: https://github.com/openmobilityfoundation/mobility-data-specification/compare/0.4.1...0.4.x
 
-    * For a MINOR release like 0.5.0, compare the last release in the previous series to the current state of `dev`: https://github.com/CityOfLosAngeles/mobility-data-specification/compare/master...dev
+    * For a MINOR release like 0.5.0, compare the last release in the previous series to the current state of `dev`: https://github.com/openmobilityfoundation/mobility-data-specification/compare/master...dev
 
     In the case of a new MINOR version, allow a minimum of 24 hours for community discussion and review of the current state of the release.
 
@@ -246,11 +246,11 @@ The following steps **must** be followed for **every** release of MDS:
 
 1. Publish a [new Release in GitHub][mds-releases-new] for the tag you just pushed. Copy in the [release notes](ReleaseNotes.md) created earlier.
 
-1. Post a release announcement to [`mds-announce`](mailto:mds-announce@googlegroups.com), copying the [release notes](ReleaseNotes.md) created earlier and linking to the [GitHub release][mds-releases].
+1. Post a release announcement to [`mds-announce`](mailto:mds-announce@groups.openmobilityfoundation.org), copying the [release notes](ReleaseNotes.md) created earlier and linking to the [GitHub release][mds-releases].
 
     ```email
-    From:    mds-announce@googlegroups.com  
-    To:      mds-announce@googlegroups.com  
+    From:    mds-announce@groups.openmobilityfoundation.org  
+    To:      mds-announce@groups.openmobilityfoundation.org  
     Subject: MDS 1.2.3 Release  
 
     MDS 1.2.3 has been released.
@@ -260,7 +260,7 @@ The following steps **must** be followed for **every** release of MDS:
     <link to GitHub release>
     ```
 
-[mds-announce]: https://groups.google.com/forum/#!forum/mds-announce
+[mds-announce]: https://groups.google.com/a/groups.openmobilityfoundation.org/forum/#!forum/mds-announce
 [mds-dev]: https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev
 [mds-master]: https://github.com/CityOfLosAngeles/mobility-data-specification/tree/master
 [mds-milestones]: https://github.com/CityOfLosAngeles/mobility-data-specification/milestones


### PR DESCRIPTION
References issue [#386]([https://github.com/openmobilityfoundation/mobility-data-specification/issues/386).

### Explain pull request

These syntax corrections are required as the result of the repository move from the CityofLosAngeles github organization to the OpenMobilityFoundation.

### Is this a breaking change

 * No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * No impact on specs

### Additional context

None
