### PR TITLE
event_type reserved now explicitly means taking possession

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -367,11 +367,11 @@ Without an `event_time` query parameter, `/status_changes` shall return a `400 B
 | `event_type` | Description | `event_type_reason` | Description |
 | ---------- | ---------------------- | ------- | ------------------ |
 | `available` | A device becomes available for customer use | `service_start` | Device introduced into service at the beginning of the day (if program does not operate 24/7) |
-| | | `user_drop_off` | User ends reservation |
+| | | `user_drop_off` | User ends possession |
 | | | `rebalance_drop_off` | Device moved for rebalancing |
 | | | `maintenance_drop_off` | Device introduced into service after being removed for maintenance |
 | | | `agency_drop_off` | The administrative agency (ie, DOT) drops a device into the PROW using an admin code or similar | 
-| `reserved` | A customer reserves a device (even if trip has not started yet) | `user_pick_up` | Customer reserves device |
+| `reserved` | A customer takes possession of a device (trip has started or is about to start) | `user_pick_up` | Customer takes possession of device |
 | `unavailable` | A device is on the street but becomes unavailable for customer use | `maintenance` | A device is no longer available due to equipment issues |
 | | | `low_battery` | A device is no longer available due to insufficient battery |
 | `removed` | A device is removed from the street and unavailable for customer use | `service_end` | Device removed from street because service has ended for the day (if program does not operate 24/7) |


### PR DESCRIPTION
### Explain pull request

The status_change event_type `reserved` has caused confusion (see https://github.com/openmobilityfoundation/mobility-data-specification/issues/417). More and more providers support reservation as in future hold for a vehicle. It seemed that `reserved` was actually not meant for this use case, but just for taking possession. The requirement to have a trip_id hints at this. This PR more explicitly states the intent of the event_type `reserved` to be only when a user takes physical possession of the vehicle, not to reserve for future use. 

### Is this a breaking change

Although the API definitions strictly remain the same, both API clients and implementations may have to be adjusted.

 * I'm not sure

### Impacted Spec

 * `provider`

### Additional context

Agency has `trip_start` and `reserved`, this means that Provider `reserved` is comparable to Agency `trip_start`
