### PR TITLE
Clarify no pagination on static provider endpoints /trips and /status_changes

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -113,7 +113,10 @@ MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-sc
 
 ### Pagination
 
-`provider` APIs may decide to paginate the data payload. If so, pagination must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
+The `/trips` and `/status_changes` APIs should not use pagination.
+If providers choose to use pagination for the `/events` endpoint the pagination
+must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination)
+specification.
 
 The following keys must be used for pagination links:
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -113,7 +113,7 @@ MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-sc
 
 ### Pagination
 
-The `/trips` and `/status_changes` APIs should not use pagination.
+The `/trips` and `/status_changes` APIs must not use pagination.
 If providers choose to use pagination for the `/events` endpoint the pagination
 must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination)
 specification.


### PR DESCRIPTION
### Explain pull request

It clarifies that the static provider endpoints (/trips and /status_changes) should not have server-side pagination.

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * No, not breaking


### Impacted Spec

Which spec(s) will this pull request impact?

 * `provider`

### Additional context

As one of the contributors who proposed the original static-file backed provider endpoint idea for /trips and /status_changes endpoints, I believe it's important that there should be no server-side pagination on the short time intervals. 

Longer explanation is copied from my original post [here](https://github.com/openmobilityfoundation/mobility-data-specification/pull/357#issuecomment-544653160):

---

One more important point I'd like to raise is the removal of pagination from static-backed endpoints.

1\. Pagination currently is the most "broken" part of the MDS specs. I work on MDS acquisition at Populus, we work with 10+ operators' MDS API, and pagination code is by far the most complex part of our MDS acquisition infrastructure. Most operators have slightly different behavior, and errors are not uncommon.

Some operators do not support pagination at all but require us to query data in hourly blocks (exactly like the new static endpoints), some do not add links to the last page, some require custom query parameters and the list goes on.

2\. Since on the static endpoints, the time-period is fixed, I went ahead and analyzed all our historical data.

=> The average size for an hourly block of trips data, gzipped is 100 kB.
=> The maximum, extreme value for an hourly block of trips data is 7 MB, but this is very rare.

Since we are talking about servers in datacenters communicating with each other, even sending 7 MB in a single HTTPS request should be a non-issue today. Status changes are tiny in comparison, there is no point in analyzing them.

=> As a conclusion, I recommend removing pagination from the static-backed endpoints (provider /trips and /status_changes).