### PR TITLE
Clarify "data does not exist" vs empty data for trips and status changes

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -185,13 +185,32 @@ The `/trips` API should allow querying trips with the following query parameters
 | --------------- | ------ | --------------- |
 | `end_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All trips with an end time occurring within the hour. For example, requesting `end_time=2019-10-01T07` returns all trips where `2019-10-01T07:00:00 <= trip.end_time < 2019-10-01T08:00:00` UTC. |
 
-If the provider was operational during the requested hour the provider shall return
-a 200 response, even if there are no trips to report (in which case
-the response will contain an empty list of trips).
-If the requested hour occurs in a time period in which the provider was not operational
-or the hour is not yet in the past `/trips` shall return a `404 Not Found` error.
-
 Without an `end_time` query parameter, `/trips` shall return a `400 Bad Request` error.
+
+### Trips - Responses
+
+The API's response will depend on the hour queried and the status of data
+processing for that hour:
+
+* For hours that are not yet in the past the API shall return a `404 Not Found`
+  response.
+* For hours in which the provider was not operating the API shall return a
+  `404 Not Found` response.
+* For hours that are in the past but for which data is not yet available
+  the API shall return a `102 Processing` response.
+* For all other hours the API shall return a `200 OK` response with a fully
+  populated body, even for hours that contain no trips to report.
+  If the hour has no trips to report the response shall contain an empty
+  array of trips:
+  
+    ```json
+    {
+        "version": "x.y.z",
+        "data": {
+            "trips": []
+        }
+    }
+    ```
 
 For the near-ish real time use cases, please use the [events][events] endpoint.
 
@@ -287,13 +306,32 @@ The `/status_changes` API should allow querying status changes with the followin
 | --------------- | ------ | --------------- |
 | `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `2019-10-01T07:00:00 <= status_change.event_time < 2019-10-01T08:00:00` UTC. |
 
-If the provider was operational during the requested hour the provider shall return
-a 200 response, even if there are no status changes to report (in which case
-the response will contain an empty list of status changes).
-If the requested hour occurs in a time period in which the provider was not operational
-or the hour is not yet in the past `/status_changes` shall return a `404 Not Found` error.
-
 Without an `event_time` query parameter, `/status_changes` shall return a `400 Bad Request` error.
+
+### Status Changes - Responses
+
+The API's response will depend on the hour queried and the status of data
+processing for that hour:
+
+* For hours that are not yet in the past the API shall return a `404 Not Found`
+  response.
+* For hours in which the provider was not operating the API shall return a
+  `404 Not Found` response.
+* For hours that are in the past but for which data is not yet available
+  the API shall return a `102 Processing` response.
+* For all other hours the API shall return a `200 OK` response with a fully
+  populated body, even for hours that contain no status changes to report.
+  If the hour has no status changes to report the response shall contain an
+  empty array of status changes:
+  
+    ```json
+    {
+        "version": "x.y.z",
+        "data": {
+            "status_changes": []
+        }
+    }
+    ```
 
 [Top][toc]
 


### PR DESCRIPTION
### Explain pull request

The trips and status changes endpoints are expected to return HTTP 404 responses when data "does not exist". I'm trying to clarify that that means the future and hours when the provider was not in operation in the municipality. For past hours during which the provider was operating but nothing happened they should return empty arrays of trips or status changes.

I'm guessing, but not totally sure, that this was the original intent.

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `provider`

### Additional context

See #357 for the PR in which `/trips` and `/status_changes` were switched to this hourly format.
