### PR TITLE
Add Docked Bikeshare Systems (and Stops History)

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -225,6 +225,13 @@ If the currency field is null, USD cents is implied.
 
 [Top][toc]
 
+
+### Station ID
+
+A station is where a vehicle may be picked up and/or returned. Each station must have a UUID that is unique within the Provider's system. This is not to be confused with the station ID that may be found from a [GBFS](https://github.com/NABSA/gbfs/) endpoint.
+
+[Top][toc]
+
 ## Trips
 
 A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.
@@ -259,6 +266,8 @@ Schema: [`trips` schema][trips-schema]
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies](#costs--currencies)) |
 | `actual_cost` | Integer | Optional | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider (see [Costs & Currencies](#costs--currencies)) |
 | `currency` | String | Optional, USD cents is implied if null.| An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee (see [Costs & Currencies](#costs--currencies)) |
+| `station_start` | UUID | Required if Applicable | If a trip originates from a station, the [station id](#station-id) of the station |
+| `station_end` | UUID | Required if Applicable | If a trip ends at a station, the [station id](#station-id) of the station |
 
 ### Trips Query Parameters
 
@@ -342,6 +351,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [Event Times](#event-times) |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that event became available through the status changes endpoint |
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
+| `event_station_id` | UUID | Required if Applicable | If the event occurs at a station, the [station id](#station-id) of the station |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type_reason` is `user_pick_up` or `user_drop_off`, or for any other status change event that marks the end of a trip. |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. | 


### PR DESCRIPTION
### Explain pull request

With issues #374 , #428 , and #438  it seems there's an ever-increasing desire to bring docked-bikeshare information into MDS.

We propose minor additions to the existing `/trips` and `/status_changes` endpoints and also the addition of new `/stations` and `/station_status_changes` endpoints. The two new endpoints are undoubtedly modeled after GBFS; however they’re intended for historical queries, unlike GBFS's primary purpose of providing "real-time travel advice" to bikeshare riders.

To update **trips** to support docks (issue #428 ), we should add two new optional fields: `station_start` and `station_end`. If a vehicle starts and/or ends its trip at a station, the fields would be populated with the station ID(s).

For **status changes** (issue #438 ), there will be an optional `event_station_id` field, whose purpose is similar to the above. If a device has a status change that occurs at a station, then the field will be populated with the station ID.

For actual information on stations (issue #374 ), we’ve split this into two endpoints: `/stations` and `/station_status_changes`.

The reason for this separation is because the `/stations` endpoint guarantees that the user will get an inventory of all stations at predictable point in time. Since it’s costly and redundant to store the state of a station of every possible historical point in time, this endpoint would provide states on a daily cadence. To get the state at any other point in time, the user would use the  `/station_status_changes` endpoint; which is a stream of events.

So with two endpoints, a consumer of the API can recreate the state of any station at any point in the past without needing to start from the very beginning.

Lastly, I want disclose that I may not have the availability to shepherd this proposal all the way to completion. If someone else in the MDS community would like to take the reins on this, I welcome your support.

### Is this a breaking change

This PR adds optional fields to existing endpoints and proposes the addition of two new endpoints.

* No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `provider`

### Issues for Discussion

Which spec(s) will this pull request impact?

 * `provider`

### Issues for Discussion

- We chose to use `Vehicles[]` and `Docks[]` instead of a field like `num_bikes_available` so that the station may support any type of vehicle without requiring any changes to the schema. GBFS currently has an issue with representing ebike counts, where some providers have started using their own unofficial field like `num_ebikes_available`. I'm well aware of the performance implications when parsing, but the approach of stringifying `vehicle_types` and `propulsion_types` as keys seems suboptimal as well. E.g.

```
{
  num_bike_human_available: 10,
  num_bike_electric_assist_available: 5,
  num_scooter_electric_available: 3
}
```

- Stations have `vehicle_types` and `propulsion_types` fields, which represent what that station supports, however it doesn’t list the specific combination (e.g. an ebike is a `bike` and `electric_assist`). To do so would require the creation of some third object that would combine `vehicle_type` and `propulsion_type`. This was purposely omitted to reduce complexity.

- The `Vehicles` object, given its inclusion of `device_id` and `vehicle_id`, will allow a user to recreate trips. This is a minor privacy concern, especially when compared to routes [routes](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/provider#routes) because because docked trips are "snapped" to stations, so the level of trip detail here is coarser.

- Do we want to try to align station `change_type_reasons` with the existing agency and provider `event_type` [framework](https://github.com/openmobilityfoundation/mobility-data-specification/issues/271)?
