### PR TITLE
Add stop references to trips and status_changes

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -108,6 +108,8 @@ All String fields, such as `vehicle_id`, are limited to a maximum of 255 charact
 
 ## Stops
 
+**Stops** describe vehicle trip end locations in a pre-designated physical place. They can vary from docking stations with our without charging, corrals with lock-to railings, or suggested parking areas marked with spray paint.  **Stops** are used in both [Provider](/provider#stops) (including routes and event locations) and [Agency](/agency#stops) (including telemetry data).
+
 | Field                  | Type                                                        | Required/Optional | Description                                                                                  |
 |------------------------|-------------------------------------------------------------|-------------------|----------------------------------------------------------------------------------------------|
 | stop_id                | UUID                                                        | Required          | Unique ID for stop                                                                           |
@@ -133,11 +135,23 @@ All String fields, such as `vehicle_id`, are limited to a maximum of 255 charact
 
 ### Stop Status
 
+**Stop Status** returns information about the current status of a **[Stop](#stops)**.
+
 | Field        | Type    | Required/Optional | Description                                         |
 |--------------|---------|-------------------|-----------------------------------------------------|
 | is_installed | Boolean | Required          | See GBFS [station_status.json][gbfs-station-status] |
 | is_renting   | Boolean | Required          | See GBFS [station_status.json][gbfs-station-status] |
 | is_returning | Boolean | Required          | See GBFS [station_status.json][gbfs-station-status] |
+
+Example of the **Stop Status** object with properties listed:
+
+```json
+ {
+  "is_installed": true,
+  "is_renting": false,
+  "is_returning": true
+ }
+```
 
 ### GBFS Compatibility
 

--- a/general-information.md
+++ b/general-information.md
@@ -108,7 +108,7 @@ All String fields, such as `vehicle_id`, are limited to a maximum of 255 charact
 
 ## Stops
 
-**Stops** describe vehicle trip end locations in a pre-designated physical place. They can vary from docking stations with our without charging, corrals with lock-to railings, or suggested parking areas marked with spray paint.  **Stops** are used in both [Provider](/provider#stops) (including routes and event locations) and [Agency](/agency#stops) (including telemetry data).
+**Stops** describe vehicle trip end locations in a pre-designated physical place. They can vary from docking stations with or without charging, corrals with lock-to railings, or suggested parking areas marked with spray paint.  **Stops** are used in both [Provider](/provider#stops) (including routes and event locations) and [Agency](/agency#stops) (including telemetry data).
 
 | Field                  | Type                                                        | Required/Optional | Description                                                                                  |
 |------------------------|-------------------------------------------------------------|-------------------|----------------------------------------------------------------------------------------------|

--- a/general-information.md
+++ b/general-information.md
@@ -264,7 +264,7 @@ If an unsupported or invalid version is requested, the API must respond with a s
 
 [agency]: /agency/README.md
 [gbfs-station-info]: https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_informationjson
-[gbfs-station-status]: https://github.com/NABSA/gbfs/blob/v2.1-RC/gbfs.md#station_statusjson
+[gbfs-station-status]: https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_statusjson
 [policy]: /policy/README.md
 [provider]: /provider/README.md
 [toc]: #table-of-contents

--- a/provider/README.md
+++ b/provider/README.md
@@ -180,9 +180,9 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 | `route` | GeoJSON `FeatureCollection` | Required | See [Routes](#routes) detail below |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |
 | `start_time` | [timestamp][ts] | Required | |
-| `start_stop_id` | UUID | Required (*docked*), Optional (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
+| `start_stop_id` | UUID | Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `end_time` | [timestamp][ts] | Required | |
-| `end_stop_id` | UUID | Required (*docked*), Optional (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
+| `end_stop_id` | UUID | Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that trip became available through the trips endpoint |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies][costs-and-currencies]) |

--- a/provider/README.md
+++ b/provider/README.md
@@ -180,9 +180,7 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 | `route` | GeoJSON `FeatureCollection` | Required | See [Routes](#routes) detail below |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |
 | `start_time` | [timestamp][ts] | Required | |
-| `start_stop_id` | UUID | Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `end_time` | [timestamp][ts] | Required | |
-| `end_stop_id` | UUID | Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that trip became available through the trips endpoint |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies][costs-and-currencies]) |
@@ -209,13 +207,16 @@ To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollect
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS][agps] is accurate to 5 decimal places, [differential GPS][dgps] is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
+*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `proprerties` object.
+
 ```js
 "route": {
     "type": "FeatureCollection",
     "features": [{
         "type": "Feature",
         "properties": {
-            "timestamp": 1529968782421
+            "timestamp": 1529968782421,
+            "stop_id": "95084833-6a3f-4770-9919-de1ab4b8989b", // REQUIRED for docked mobility providers, N/A for dockless
         },
         "geometry": {
             "type": "Point",
@@ -228,7 +229,8 @@ Routes must include at least 2 points: the start point and end point. Routes mus
     {
         "type": "Feature",
         "properties": {
-            "timestamp": 1531007628377
+            "timestamp": 1531007628377,
+            "stop_id": "b813cde2-a41c-4ae3-b409-72ff221e003d" // REQUIRED for docked mobility providers, N/A for dockless
         },
         "geometry": {
             "type": "Point",
@@ -275,7 +277,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
-| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `reserved` events with a `user_pick_up` event_type_reason, and `available` events with a `user_drop_off` event_type_reason for a *docked* mobility provider. |
+| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip_start` and `trip_end` events for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -275,7 +275,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
-| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip_start` and `trip_end` events for a *docked* mobility provider. |
+| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip` events for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -277,7 +277,6 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
-| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip_start` and `trip_end` events for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -275,7 +275,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
-| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `reserved` events, and `available` events which have a `user_drop_off` event_type_reason for a *docked* mobility provider. |
+| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `reserved` events with a `user_pick_up` event_type_reason, and `available` events with a `user_drop_off` event_type_reason for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -180,7 +180,9 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 | `route` | GeoJSON `FeatureCollection` | Required | See [Routes](#routes) detail below |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |
 | `start_time` | [timestamp][ts] | Required | |
+| `start_stop_id` | UUID | Required (*docked*), Optional (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `end_time` | [timestamp][ts] | Required | |
+| `end_stop_id` | UUID | Required (*docked*), Optional (*dockless*) | Identifier for a stop see [Stops](LINKTBD). |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that trip became available through the trips endpoint |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies][costs-and-currencies]) |
@@ -272,7 +274,8 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
-| `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system |
+| `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
+| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip_start` and `trip_end` events for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -207,7 +207,7 @@ To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollect
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS][agps] is accurate to 5 decimal places, [differential GPS][dgps] is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
-*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `proprerties` object.
+*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `properties` object.
 
 ```js
 "route": {
@@ -216,7 +216,7 @@ Routes must include at least 2 points: the start point and end point. Routes mus
         "type": "Feature",
         "properties": {
             "timestamp": 1529968782421,
-            "stop_id": "95084833-6a3f-4770-9919-de1ab4b8989b", // REQUIRED for docked mobility providers, N/A for dockless
+            "stop_id": "95084833-6a3f-4770-9919-de1ab4b8989b", // REQUIRED for docked mobility providers, optional for dockless
         },
         "geometry": {
             "type": "Point",
@@ -230,7 +230,7 @@ Routes must include at least 2 points: the start point and end point. Routes mus
         "type": "Feature",
         "properties": {
             "timestamp": 1531007628377,
-            "stop_id": "b813cde2-a41c-4ae3-b409-72ff221e003d" // REQUIRED for docked mobility providers, N/A for dockless
+            "stop_id": "b813cde2-a41c-4ae3-b409-72ff221e003d" // REQUIRED for docked mobility providers, optional for dockless
         },
         "geometry": {
             "type": "Point",

--- a/provider/README.md
+++ b/provider/README.md
@@ -207,7 +207,7 @@ To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollect
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS][agps] is accurate to 5 decimal places, [differential GPS][dgps] is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
-*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `properties` object, as all trips for docked vehicles should originate/end at [Stops](/general-information.md#stop).
+*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `properties` object, as all trips for docked vehicles should originate/end at [Stops](/general-information.md#stops).
 
 ```js
 "route": {
@@ -280,7 +280,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 
 ### Event Locations
 
-*Docked* mobility providers must include a `stop_id` in the Point Feature of each `event_location` that occurs at a [Stop](/general-information.md#stop) by embedding the `stop_id` property in the Feature's `properties` object.
+*Docked* mobility providers must include a `stop_id` in the Point Feature of each `event_location` that occurs at a [Stop](/general-information.md#stops) by embedding the `stop_id` property in the Feature's `properties` object.
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -273,10 +273,14 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `event_types` | Enum[] | Required | [Vehicle event(s)][vehicle-events] for state change, allowable values determined by `vehicle_state` |
 | `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [Event Times][event-times] |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that event became available through the status changes endpoint |
-| `event_location` | GeoJSON [Point Feature][geo] | Required | |
+| `event_location` | GeoJSON [Point Feature][geo] | Required | See [event_locations](#event-locations)|
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
+
+### Event Locations
+
+*Docked* mobility providers must include a `stop_id` in the Point Feature of each `event_location` that occurs at a `Stop` by embedding the `stop_id` property in the Feature's `properties` object.
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -280,7 +280,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 
 ### Event Locations
 
-*Docked* mobility providers must include a `stop_id` in the Point Feature of each `event_location` that occurs at a `Stop` by embedding the `stop_id` property in the Feature's `properties` object.
+*Docked* mobility providers must include a `stop_id` in the Point Feature of each `event_location` that occurs at a [Stop](/general-information.md#stop) by embedding the `stop_id` property in the Feature's `properties` object.
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -275,7 +275,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `trip_id` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_types` contains `trip_start`, `trip_end`, `trip_cancel`, `trip_enter_jurisdiction`, or `trip_leave_jurisdiction` |
 | `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
-| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `trip` events for a *docked* mobility provider. |
+| `stop_id` | UUID | Conditionally Required (*docked*), N/A (*dockless*) | Identifier for a stop see [Stops](LINKTBD). Required for `reserved` events, and `available` events which have a `user_drop_off` event_type_reason for a *docked* mobility provider. |
 
 ### Status Changes Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -207,7 +207,7 @@ To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollect
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS][agps] is accurate to 5 decimal places, [differential GPS][dgps] is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
-*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `properties` object.
+*Docked* mobility providers must include a `stop_id` in the first and last Feature of each `route` by embedding the `stop_id` property in the Feature's `properties` object, as all trips for docked vehicles should originate/end at [Stops](/general-information.md#stop).
 
 ```js
 "route": {

--- a/provider/events.json
+++ b/provider/events.json
@@ -69,6 +69,9 @@
           "properties": {
             "timestamp": {
               "$ref": "#/definitions/timestamp"
+            },
+            "stop_id": {
+              "$ref": "#/definitions/uuid"
             }
           }
         },

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -69,6 +69,9 @@
           "properties": {
             "timestamp": {
               "$ref": "#/definitions/timestamp"
+            },
+            "stop_id": {
+              "$ref": "#/definitions/uuid"
             }
           }
         },

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -69,6 +69,9 @@
           "properties": {
             "timestamp": {
               "$ref": "#/definitions/timestamp"
+            },
+            "stop_id": {
+              "$ref": "#/definitions/uuid"
             }
           }
         },

--- a/provider/vehicles.json
+++ b/provider/vehicles.json
@@ -69,6 +69,9 @@
           "properties": {
             "timestamp": {
               "$ref": "#/definitions/timestamp"
+            },
+            "stop_id": {
+              "$ref": "#/definitions/uuid"
             }
           }
         },

--- a/schema/generate_schemas.py
+++ b/schema/generate_schemas.py
@@ -325,8 +325,16 @@ def provider_schema(endpoint, common_definitions, extra_definitions={}):
         title = "MDS GeoJSON Feature Point",
         # Only allow GeoJSON Point feature geometry
         geometry = { "$ref": definition_id("Point") },
-        # Point features *must* include a `timestamp` property.
-        properties = { "timestamp": { "$ref": definition_id("timestamp") } },
+        properties = {
+            "timestamp": {
+                "$ref": definition_id("timestamp")
+            },
+            # Locations corresponding to Stops must include a `stop_id` reference
+            "stop_id": {
+                "$ref": definition_id("uuid")
+            }
+        },
+        # Point features *must* include the `timestamp`
         required = ["timestamp"]
     )
 


### PR DESCRIPTION
### Explain pull request
Resolves #428 following @jfh01's suggestion to use GeoJSON Foreign Members. Relates pretty closely to the open PR #427, and is dependent on that being merged first.

### Is this a breaking change

 * No, not breaking

### Impacted Spec

 * `provider`