### PR TITLE
Add missing/lost event to provider spec

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -378,6 +378,7 @@ Without an `event_time` query parameter, `/status_changes` shall return a `400 B
 | | | `rebalance_pick_up` | Device removed from street and will be placed at another location to rebalance service |
 | | | `maintenance_pick_up` | Device removed from street so it can be worked on |
 | | | `agency_pick_up` | The administrative agency (ie, DOT) removes a device using an admin code or similar |
+| `missing` | A vehicle's status is unknown. | `lost` |  A vehicle is missing but not yet deactivated from the fleet. |
 
 [Top][toc]
 


### PR DESCRIPTION
### Explain pull request

This is a companion pull request to #429 to add a "missing"/"lost" event to the provider spec. My hope is to unblock #376 (`/vehicles` endpoint). I'm not at all sure I've done this correctly, so pointers appreciated.

It might also be worth noting that this event type would be changing to "unknown" in the future per @thekidder's suggestion in https://github.com/openmobilityfoundation/mobility-data-specification/issues/271#issuecomment-582243658.

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * No, not breaking

This only adds a field so I don't think it's breaking, but not 100% sure on the conventions here.

### Impacted Spec

Which spec(s) will this pull request impact?

 * `provider`

### Additional context

Add any other context or screenshots about the feature request here.
