### PR TITLE
Add language around targeting dev branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,29 @@
-### Explain pull request
+# MDS Pull Request
+
+Thank you for your contribution!
+
+*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev)*. Please ensure you are targetting `dev` to avoid complications and help make the Review process as smooth as possible.
+
+## Explain pull request
 
 Please provide a clear and concise reason for this pull request and the impact of the change
 
-### Is this a breaking change
+## Is this a breaking change
 
-A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
+A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint).
 
- * Yes, breaking
- * No, not breaking
- * I'm not sure
+* Yes, breaking
+* No, not breaking
+* I'm not sure
 
-### Impacted Spec
+## Impacted Spec
 
 Which spec(s) will this pull request impact?
 
- * `agency`
- * `policy`
- * `provider`
+* `agency`
+* `policy`
+* `provider`
 
-### Additional context
+## Additional context
 
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Thank you for your contribution!
 
-*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev)*. Please ensure you are targetting `dev` to avoid complications and help make the Review process as smooth as possible.
+*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev). Please ensure you are targeting **`dev`** to avoid complications and help make the Review process as smooth as possible.*
 
 ## Explain pull request
 


### PR DESCRIPTION
### Explain pull request

As discussed on the [2020/02/27 Provider Services call](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-conference-notes,-2020.02.27-(Provider-Services-wg)), this PR updates the PR template to remind folks to target the `dev` branch.

### Is this a breaking change

* No, not breaking

### Impacted Spec

* N/A