### PR TITLE
Schema fixes/updates

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -76,10 +76,10 @@ MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-sc
 
 ### Pagination
 
-The `/trips` and `/status_changes` APIs must not use pagination.
-If providers choose to use pagination for the `/events` endpoint the pagination
-must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination)
-specification.
+The `/trips` and `/status_changes` endpoints must not use pagination.
+
+If providers choose to use pagination for either of the `/events` or `/vehicles` endpoints, the pagination
+must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
 
 The following keys must be used for pagination links:
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -376,7 +376,7 @@ The schema and datatypes are the same as those defined for [`/status_changes`][s
 **Endpoint:** `/events`  
 **Method:** `GET`  
 **Required/Optional:** Optional starting with `0.4.0`, moving to Required in a future version (`0.5.0`+)  
-**Schema:** [`status_changes` schema][sc-schema]  
+**Schema:** [`events` schema][events-schema]  
 **`data` Payload:** `{ "status_changes": [] }`, an array of objects with the same structure as in [`/status_changes`][status]
 
 #### Event Times
@@ -445,6 +445,7 @@ ttl                 | Yes       | Integer representing the number of millisecond
 
 [general-information/versioning]: /general-information.md#versioning
 [geo]: #geographic-data
+[events-schema]: dockless/events.json
 [sc-schema]: dockless/status_changes.json
 [status]: #status-changes
 [toc]: #table-of-contents

--- a/provider/dockless/events.json
+++ b/provider/dockless/events.json
@@ -1,0 +1,294 @@
+{
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/events.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Provider Schema, events payload",
+  "type": "object",
+  "definitions": {
+    "links": {
+      "$id": "#/definitions/links",
+      "type": "object",
+      "required": [
+        "next"
+      ],
+      "properties": {
+        "first": {
+          "$id": "#/definitions/links/first",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the first page of data",
+          "examples": [
+            "https://data.provider.co/trips/first"
+          ],
+          "format": "uri"
+        },
+        "last": {
+          "$id": "#/definitions/links/last",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the last page of data",
+          "examples": [
+            "https://data.provider.co/trips/last"
+          ],
+          "format": "uri"
+        },
+        "prev": {
+          "$id": "#/definitions/links/prev",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the previous page of data",
+          "examples": [
+            "https://data.provider.co/trips/prev"
+          ],
+          "format": "uri"
+        },
+        "next": {
+          "$id": "#/definitions/links/next",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the next page of data",
+          "examples": [
+            "https://data.provider.co/trips/next"
+          ],
+          "format": "uri",
+          "pattern": "^(.*)$"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "version",
+    "data"
+  ],
+  "properties": {
+    "version": {
+      "$id": "#/properties/version",
+      "$ref": "#/definitions/version"
+    },
+    "data": {
+      "$id": "#/properties/data",
+      "type": "object",
+      "title": "The page of data",
+      "required": [
+        "status_changes"
+      ],
+      "properties": {
+        "status_changes": {
+          "$id": "#/properties/data/properties/status_changes",
+          "type": "array",
+          "title": "The status_changes payload",
+          "items": {
+            "$id": "#/properties/data/properties/status_changes/items",
+            "type": "object",
+            "title": "The status_change item schema",
+            "required": [
+              "provider_name",
+              "provider_id",
+              "device_id",
+              "vehicle_id",
+              "vehicle_type",
+              "propulsion_type",
+              "event_type",
+              "event_type_reason",
+              "event_time",
+              "event_location"
+            ],
+            "properties": {
+              "provider_name": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/provider_name",
+                "type": "string",
+                "description": "The public-facing name of the Provider",
+                "examples": [
+                  "Provider Name"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "provider_id": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/provider_id",
+                "description": "The UUID for the Provider, unique within MDS",
+                "$ref": "#/definitions/uuid"
+              },
+              "device_id": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/device_id",
+                "description": "A unique device ID in UUID format",
+                "$ref": "#/definitions/uuid"
+              },
+              "vehicle_id": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/vehicle_id",
+                "type": "string",
+                "description": "The Vehicle Identification Number visible on the vehicle itself",
+                "default": "",
+                "examples": [
+                  "ABC123"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "vehicle_type": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/vehicle_type",
+                "$ref": "#/definitions/vehicle_type",
+                "description": "The type of vehicle"
+              },
+              "propulsion_type": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/propulsion_type",
+                "description": "The type of propulsion; allows multiple values",
+                "$ref": "#/definitions/propulsion_type"
+              },
+              "event_time": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/event_time",
+                "description": "The time the event occurred, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
+              "publication_time": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/publication_time",
+                "description": "The time the event became available through the status changes endpoint, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
+              "event_location": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
+                "description": "The GPS or GNSS coordinates of where the event occurred",
+                "$ref": "#/definitions/MDS_Feature_Point"
+              },
+              "event_type": {
+                "type": "string",
+                "description": "The type of the event"
+              },
+              "event_type_reason": {
+                "type": "string",
+                "description": "The reason for the event"
+              },
+              "battery_pct": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/battery_pct",
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Percent charge of device battery, expressed between 0 and 1",
+                "examples": [
+                  0.89
+                ],
+                "minimum": 0,
+                "maximum": 1
+              },
+              "associated_trip": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/associated_trip",
+                "description": "Trip UUID, required if event_type_reason is user_pick_up or user_drop_off",
+                "$ref": "#/definitions/uuid"
+              },
+              "associated_ticket": {
+                "type": "string",
+                "description": "Identifier for an associated ticket inside an Agency-maintained 311 or CRM system."
+              }
+            },
+            "allOf": [
+              {
+                "description": "valid event_type and event_type_reason combinations",
+                "oneOf": [
+                  {
+                    "properties": {
+                      "event_type": {
+                        "enum": [
+                          "available"
+                        ]
+                      },
+                      "event_type_reason": {
+                        "enum": [
+                          "service_start",
+                          "user_drop_off",
+                          "rebalance_drop_off",
+                          "maintenance_drop_off",
+                          "agency_drop_off"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "event_type": {
+                        "enum": [
+                          "reserved"
+                        ]
+                      },
+                      "event_type_reason": {
+                        "enum": [
+                          "user_pick_up"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "event_type": {
+                        "enum": [
+                          "unavailable"
+                        ]
+                      },
+                      "event_type_reason": {
+                        "enum": [
+                          "low_battery",
+                          "maintenance"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "event_type": {
+                        "enum": [
+                          "removed"
+                        ]
+                      },
+                      "event_type_reason": {
+                        "enum": [
+                          "service_end",
+                          "rebalance_pick_up",
+                          "maintenance_pick_up",
+                          "agency_pick_up"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "description": "conditionally require associated_trip when applicable",
+                "anyOf": [
+                  {
+                    "not": {
+                      "properties": {
+                        "event_type_reason": {
+                          "enum": [
+                            "user_pick_up",
+                            "user_drop_off"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "required": [
+                      "associated_trip"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "$id": "#/properties/links",
+      "$ref": "#/definitions/links"
+    }
+  },
+  "additionalProperties": false
+}

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -216,11 +216,11 @@
         "status_changes": {
           "$id": "#/properties/data/properties/status_changes",
           "type": "array",
-          "title": "The status_changes Schema",
+          "title": "The status_changes payload",
           "items": {
             "$id": "#/properties/data/properties/status_changes/items",
             "type": "object",
-            "title": "The Items Schema",
+            "title": "The status_change item schema",
             "required": [
               "provider_name",
               "provider_id",

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -416,10 +416,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "links": {
-      "$id": "#properties/links",
-      "$ref": "#/definitions/links"
     }
   },
   "additionalProperties": false

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -410,10 +410,6 @@
           }
         }
       }
-    },
-    "links": {
-      "$id": "#properties/links",
-      "$ref": "#/definitions/links"
     }
   },
   "additionalProperties": false

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -247,11 +247,11 @@
         "trips": {
           "$id": "#/properties/data/properties/trips",
           "type": "array",
-          "title": "The Trips Schema",
+          "title": "The trips payload",
           "items": {
             "$id": "#/properties/data/properties/trips/items",
             "type": "object",
-            "title": "The Trip Schema",
+            "title": "The trip item schema",
             "required": [
               "provider_name",
               "provider_id",

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -218,11 +218,11 @@
         "vehicles": {
           "$id": "#/properties/data/properties/vehicles",
           "type": "array",
-          "title": "The vehicles Schema",
+          "title": "The vehicles payload",
           "items": {
             "$id": "#/properties/data/properties/vehicles/items",
             "type": "object",
-            "title": "The vehicles items Schema",
+            "title": "The vehicle item schema",
             "required": [
               "provider_name",
               "provider_id",

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -367,7 +367,7 @@
       "additionalProperties": false
     },
     "links": {
-      "$id": "#properties/links",
+      "$id": "#/properties/links",
       "$ref": "#/definitions/links"
     },
     "last_updated": {

--- a/schema/generate_schemas.py
+++ b/schema/generate_schemas.py
@@ -204,8 +204,8 @@ if __name__ == '__main__':
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(vehicles)
     # Write to the `provider` directory.
-    with open("../provider/dockless/vehicles.json", "w") as statusfile:
-        statusfile.write(json.dumps(vehicles, indent=2))
+    with open("../provider/dockless/vehicles.json", "w") as vehiclesfile:
+        vehiclesfile.write(json.dumps(vehicles, indent=2))
 
     # Agency Schemas #
 

--- a/schema/generate_schemas.py
+++ b/schema/generate_schemas.py
@@ -187,6 +187,25 @@ if __name__ == '__main__':
     with open("../provider/dockless/status_changes.json", "w") as statusfile:
         statusfile.write(json.dumps(status_changes, indent=2))
 
+    ## /events Schema ##
+
+    # /events is the same as status_changes, but allows paging
+    events = dict(status_changes)
+    events["$id"] = events["$id"].replace("status_changes", "events")
+    events["title"] = "The MDS Provider Schema, events payload"
+    events["definitions"] = {
+        "links": common["definitions"]["links"]
+    }
+    events["properties"]["links"] = {
+        "$id": "#/properties/links",
+        "$ref": "#/definitions/links"
+    }
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(events)
+    # Write to the `provider` directory.
+    with open("../provider/dockless/events.json", "w") as eventsfile:
+        eventsfile.write(json.dumps(events, indent=2))
+
     ## /vehicles Schema ##
 
     # Create the standalone vehicles JSON schema by including the needed definitions

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/common.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/schema/templates/common.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, common definitions",
   "type": "object",

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -24,11 +24,11 @@
         "status_changes": {
           "$id": "#/properties/data/properties/status_changes",
           "type": "array",
-          "title": "The status_changes Schema",
+          "title": "The status_changes payload",
           "items": {
             "$id": "#/properties/data/properties/status_changes/items",
             "type": "object",
-            "title": "The Items Schema",
+            "title": "The status_change item schema",
             "required": [
               "provider_name",
               "provider_id",

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -197,10 +197,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "links": {
-      "$id": "#properties/links",
-      "$ref": "#/definitions/links"
     }
   },
   "additionalProperties": false

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -24,11 +24,11 @@
         "trips": {
           "$id": "#/properties/data/properties/trips",
           "type": "array",
-          "title": "The Trips Schema",
+          "title": "The trips payload",
           "items": {
             "$id": "#/properties/data/properties/trips/items",
             "type": "object",
-            "title": "The Trip Schema",
+            "title": "The trip item schema",
             "required": [
               "provider_name",
               "provider_id",

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -173,10 +173,6 @@
           }
         }
       }
-    },
-    "links": {
-      "$id": "#properties/links",
-      "$ref": "#/definitions/links"
     }
   },
   "additionalProperties": false

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",

--- a/schema/templates/provider/vehicles.json
+++ b/schema/templates/provider/vehicles.json
@@ -155,7 +155,7 @@
       "additionalProperties": false
     },
     "links": {
-      "$id": "#properties/links",
+      "$id": "#/properties/links",
       "$ref": "#/definitions/links"
     },
     "last_updated": {

--- a/schema/templates/provider/vehicles.json
+++ b/schema/templates/provider/vehicles.json
@@ -26,11 +26,11 @@
         "vehicles": {
           "$id": "#/properties/data/properties/vehicles",
           "type": "array",
-          "title": "The vehicles Schema",
+          "title": "The vehicles payload",
           "items": {
             "$id": "#/properties/data/properties/vehicles/items",
             "type": "object",
-            "title": "The vehicles items Schema",
+            "title": "The vehicle item schema",
             "required": [
               "provider_name",
               "provider_id",


### PR DESCRIPTION
### Explain pull request

Some of the schema templates and subsequent builds listed incorrect URLs in their `$id` property. This PR fixes these and introduces small language cleanups.

Additionally, as of `0.4.1` the `/trips` and `/status_changes` endpoints do not allow paging, which is now reflected in their respective schemas. Since `/events` does support paging, a new schema has been introduced for that endpoint, based on the `/status_changes` schema.

### Is this a breaking change

 * No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `provider`