### PR TITLE
Clarify success response for telemetry update

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -209,7 +209,7 @@ Body Params:
 
 | Field     | Type                           | Field Description                                                                                       |
 | --------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `result`  | String                         | Responds with number of successfully written telemetry data points and total number of provided points. |
+| `result`  | String                         | Responds with number of successfully written telemetry data points and total number of provided points. Format to use: `{success}/{total}`, both amounts as integers. |
 | `failures` | [Telemetry](#telemetry-data)[] | Array of failed telemetry for zero or more vehicles (empty if all successful).                          |
 
 400 Failure Response:

--- a/agency/README.md
+++ b/agency/README.md
@@ -205,11 +205,12 @@ Body Params:
 | ------------- | ------------------------------ | ----------------- | -------------------------------------------------------------------------------------- |
 | `data`        | [Telemetry](#telemetry-data)[] | Required          | Array of telemetry for one or more vehicles.                                           |
 
-201 Success Response:
+200 Success Response:
 
-| Field     | Type                           | Field Description                                                                                       |
-| --------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `result`  | String                         | Responds with number of successfully written telemetry data points and total number of provided points. Format to use: `{success}/{total}`, both amounts as integers. |
+| Field      | Type                           | Field Description                                                                                       |
+| ---------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `success`  | Integer                        | Number of successfully written telemetry data points.                                                   |
+| `total`    | Integer                        | Ttotal number of provided points.                                                                       |
 | `failures` | [Telemetry](#telemetry-data)[] | Array of failed telemetry for zero or more vehicles (empty if all successful).                          |
 
 400 Failure Response:


### PR DESCRIPTION
# MDS Pull Request

Thank you for your contribution!

*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev). Please ensure you are targeting **`dev`** to avoid complications and help make the Review process as smooth as possible.*

## Explain pull request

The telemetry spec only says that when new telemetry are successfully received, the server should:

> Responds with number of successfully written telemetry data points and total number of provided points.

But the spec does not specify how those two numbers should be written.

## Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint).

* Yes, breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`

## Additional context

None