### PR TITLE
agency: Vehicle Update response code should be 200

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -139,7 +139,7 @@ Body Params:
 | ------------ | ------- | ----------------- | -------------------------------------------------------------------- |
 | `vehicle_id` | String  | Required          | Vehicle Identification Number (vehicle_id) visible on vehicle               |
 
-201 Success Response:
+200 Success Response:
 
 _No content returned on success._
 


### PR DESCRIPTION
## Explain pull request

According to the RFC : https://tools.ietf.org/html/rfc7231#section-6.3.1
the HTTP response for an update (that does not create any object) can
either be 200 (OK) or 202 (ACCEPTED)
The later "indicates that the request has been
accepted for processing, but the processing has not been completed."

Since updating the vehicle_id should be quite fast, we should use a 200
response code.

## Is this a breaking change

* Yes, breaking (since providers may check the response code when sending data)

## Impacted Spec

* `agency`

## Additional context

Add any other context or screenshots about the feature request here.
