### PR TITLE
Define "beta" features and replace the optional/required designation for endpoints

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -5,7 +5,7 @@ This document contains specifications that are shared between the various MDS AP
 ## Table of Contents
 
 * [Versioning](#versioning)
-* [Beta Features](#betafeatures)
+* [Beta Features](#beta-features)
 
 ## Versioning
 
@@ -47,10 +47,10 @@ Content-Type: application/vnd.mds.provider+json;version=0.3
 The client can use the returned value verbatim as a version request in the `Accept` header.
 
 ## Beta Features
-In some cases, features within MDS may be marked as "BETA." These are typically newly established endpoints or fields. Because beta features are new, they may not be fully mature and proven in real-world operation. The design of beta features may have undiscovered gaps, ambiguities, or inconsistencies. Implementations of those features are also likely new as well and are more likely to contain bugs or other problems. Beta features are likely to evolve more rapidly than other parts of the specification.
+In some cases, features within MDS may be marked as "beta." These are typically recently added endpoints or fields. Because beta features are new, they may not yet be fully mature and proven in real-world operation. The design of beta features may have undiscovered gaps, ambiguities, or inconsistencies. Implementations of those features are typically also quite new and are more likely to contain bugs or other flaws. Beta features are likely to evolve more rapidly than other parts of the specification.
 
-Despite this, MDS users are encouraged to use beta features. New features can only become proven and trusted through use and the learning that comes with it. Users should be thoughtful about the role of beta features in their operations. Beta features are suitable for enabling new tools and analysis, but may not be appropriate for mission-critical regulatory decisions where certainty and reliability are essential.
+Despite this, MDS users are highly encouraged to use beta features. New features can only become proven and trusted through implementation, use, and the learning that comes with it. Users should be thoughtful about the role of beta features in their operations. Beta features may be suitable for enabling some new tools and analysis, but may not be appropriate for mission-critical applications or regulatory decisions where certainty and reliability are essential.
 
-Users of beta features are strongly encouraged to share their experiences, learnings, and challenges with the broader MDS community via GitHub issues or pull requests. This will help the  community make the improvements that allow beta features to become proven, stable parts of the specification.
+Users of beta features are strongly encouraged to share their experiences, learnings, and challenges with the broader MDS community via GitHub issues or pull requests. This will inform the refinements that transform beta features into fully proven, stable parts of the specification.
 
 [Top](#table-of-contents)

--- a/general-information.md
+++ b/general-information.md
@@ -5,6 +5,7 @@ This document contains specifications that are shared between the various MDS AP
 ## Table of Contents
 
 * [Versioning](#versioning)
+* [Beta Features](#betafeatures)
 
 ## Versioning
 
@@ -44,5 +45,12 @@ Content-Type: application/vnd.mds.provider+json;version=0.3
 ```
 
 The client can use the returned value verbatim as a version request in the `Accept` header.
+
+## Beta Features
+In some cases, features within MDS may be marked as "BETA." These are typically newly established endpoints or fields. Because beta features are new, they may not be fully mature and proven in real-world operation. The design of beta features may have undiscovered gaps, ambiguities, or inconsistencies. Implementations of those features are also likely new as well and are more likely to contain bugs or other problems. Beta features are likely to evolve more rapidly than other parts of the specification.
+
+Despite this, MDS users are encouraged to use beta features. New features can only become proven and trusted through use and the learning that comes with it. Users should be thoughtful about the role of beta features in their operations. Beta features are suitable for enabling new tools and analysis, but may not be appropriate for mission-critical regulatory decisions where certainty and reliability are essential.
+
+Users of beta features are strongly encouraged to share their experiences, learnings, and challenges with the broader MDS community via GitHub issues or pull requests. This will help the  community make the improvements that allow beta features to become proven, stable parts of the specification.
 
 [Top](#table-of-contents)

--- a/provider/README.md
+++ b/provider/README.md
@@ -203,7 +203,7 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 
 **Endpoint:** `/trips`  
 **Method:** `GET`  
-**Required/Optional:** Required  
+**[Beta feature](/general-information.md#beta-features):** No  
 **Schema:** [`trips` schema][trips-schema]  
 **`data` Payload:** `{ "trips": [] }`, an array of objects with the following structure  
 
@@ -294,7 +294,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 
 **Endpoint:** `/status_changes`  
 **Method:** `GET`  
-**Required/Optional:** Required  
+**[Beta feature](/general-information.md#beta-features):** No  
 **Schema:** [`status_changes` schema][sc-schema]  
 **`data` Payload:** `{ "status_changes": [] }`, an array of objects with the following structure
 
@@ -375,7 +375,7 @@ The schema and datatypes are the same as those defined for [`/status_changes`][s
 
 **Endpoint:** `/events`  
 **Method:** `GET`  
-**Required/Optional:** Optional starting with `0.4.0`, moving to Required in a future version (`0.5.0`+)  
+**[Beta feature](/general-information.md#beta-features):** Yes (as of 0.4.0)  
 **Schema:** [`events` schema][events-schema]  
 **`data` Payload:** `{ "status_changes": [] }`, an array of objects with the same structure as in [`/status_changes`][status]
 
@@ -422,7 +422,7 @@ ttl                 | Yes       | Integer representing the number of millisecond
 
 **Endpoint:** `/vehicles`  
 **Method:** `GET`  
-**Required/Optional:** Optional starting with `0.4.1`, moving to Required in a future version (`0.5.0`+)  
+**[Beta feature](/general-information.md#beta-features):** Yes (as of 0.4.1)  
 **Schema:** [`vehicles` schema][vehicles-schema]  
 **`data` Payload:** `{ "vehicles": [] }`, an array of objects with the following structure
 


### PR DESCRIPTION
## Explain pull request

This pull request defines the idea of a "beta" feature and replaces the optional/required designation (#456) on the `provider` API endpoints with a beta yes/no designation.

This is a proposed change to the 0.4.1 release candidate that emerged from review by the OMF Technology Council. The concern identified by the Council is that "optional/required" does not clearly communicate if, when, and how an endpoint should be used. For example, is it OK for a regulator to ask a provider to implement an optional endpoint? For what purposes is it appropriate to use an optional endpoint?

The new "beta" language attempts to remove this ambiguity by honestly communicating what users can expect in terms of the completeness, quality, and stability of newly added features. Users can then make an informed decision about when and how to use beta features.

## Is this a breaking change

* No, not breaking 

## Impacted Spec

Which spec(s) will this pull request impact?

* `provider`


