### PR TITLE
Agency: vehicle register: add provider_id field

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -101,7 +101,8 @@ Body Params:
 
 | Field        | Type    | Required/Optional | Field Description                                                    |
 | ------------ | ------- | ----------------- | -------------------------------------------------------------------- |
-| `device_id`  | UUID     | Required          | Provided by Operator to uniquely identify a vehicle                 |
+| `device_id`  | UUID    | Required          | Provided by Operator to uniquely identify a vehicle                  |
+| `provider_id`| UUID    | Required          | Operator to which the vehicle belongs                                |
 | `vehicle_id` | String  | Required          | Vehicle Identification Number (vehicle_id) visible on vehicle        |
 | `type`       | Enum    | Required          | [Vehicle Type](#vehicle-type)                                        |
 | `propulsion` | Enum[]  | Required          | Array of [Propulsion Type](#propulsion-type); allows multiple values |

--- a/agency/README.md
+++ b/agency/README.md
@@ -102,10 +102,10 @@ Body Params:
 | Field        | Type    | Required/Optional | Field Description                                                    |
 | ------------ | ------- | ----------------- | -------------------------------------------------------------------- |
 | `device_id`  | UUID    | Required          | Provided by Operator to uniquely identify a vehicle                  |
-| `provider_id`| UUID    | Required          | Operator to which the vehicle belongs                                |
 | `vehicle_id` | String  | Required          | Vehicle Identification Number (vehicle_id) visible on vehicle        |
 | `type`       | Enum    | Required          | [Vehicle Type](#vehicle-type)                                        |
 | `propulsion` | Enum[]  | Required          | Array of [Propulsion Type](#propulsion-type); allows multiple values |
+| `provider_id`| UUID    | Optional          | Provider to which the vehicle belongs if different from the authenticated provider |
 | `year`       | Integer | Optional          | Year Manufactured                                                    |
 | `mfgr`       | String  | Optional          | Vehicle Manufacturer                                                 |
 | `model`      | String  | Optional          | Vehicle Model                                                        |


### PR DESCRIPTION
# MDS Pull Request

Thank you for your contribution!

*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev). Please ensure you are targeting **`dev`** to avoid complications and help make the Review process as smooth as possible.*

## Explain pull request

In several cities, the Agency is not connected directly to mobility providers. There is an aggregator in-between centralising the data from the providers and re-exposing them to the Agency.

When registering a device with the Agency API, there is currently no way for the aggregator to indicate which provider the device belongs to. This PR proposes a way to fix this.

## Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint).

* No, not breaking: only adding an optional field

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`

## Additional context

None
