### PR TITLE
rename general-information.md

### DIFF
--- a/api-versioning.md
+++ b/api-versioning.md
@@ -1,12 +1,4 @@
-# Mobility Data Specification: **General information**
-
-This document contains specifications that are shared between the various MDS APIs such as `agency`, `provider` and `policy`.
-
-## Table of Contents
-
-* [Versioning](#versioning)
-
-## Versioning
+# API Versioning
 
 MDS APIs must handle requests for specific versions of the specification from clients.
 


### PR DESCRIPTION
It was discussed in a past wg-ops meeting to change this file to be topic specific rather general

## Is this a breaking change

* No, not breaking

## Impacted Spec

N/A

## Additional context

documentation change