### PR TITLE
Add link to State of Practice Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ To stay up to date on MDS releases, meetings, and events, please **subscribe to 
 
 The Mobility Data Specification is an open source project with all development taking place on GitHub. Comments and ideas can be shared by [creating an issue](https://github.com/openmobilityfoundation/mobility-data-specification/issues), and specific changes can be suggested by [opening a pull request](https://github.com/openmobilityfoundation/mobility-data-specification/pulls). Before contributing, please review our [CONTRIBUTING page](CONTRIBUTING.md) to understand guidelines and policies for participation and our [CODE OF CONDUCT page](CODE_OF_CONDUCT.md).
 
+You can learn more about the polices, methodolgies, and tools in the MDS ecosystem in the [Mobility Data Management State of Practice](https://github.com/openmobilityfoundation/privacy-committee/wiki/Mobility-Data-Management-State-of-Practice) wiki.
+
 You can also get involved in development by joining an OMF working group. The working groups maintain the OMF GitHub repositories and work through issues and pull requests. Each working group has its own mailing list for non-technical discussion and planning:
 
 Working Group | Mailing List | Description


### PR DESCRIPTION
# MDS Pull Request

Thank you for your contribution!

*For most Pull Requests, the target branch should be [**`dev`**](https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev). Please ensure you are targeting **`dev`** to avoid complications and help make the Review process as smooth as possible.*

## Explain pull request

Addresses [#9](https://github.com/openmobilityfoundation/privacy-committee/issues/9). Update the README with a link to the Mobility Data Management State of Practice wiki, managed by the Privacy, Security, and Transparency Committee.

## Is this a breaking change

No, not breaking

## Impacted Spec

 None—README only.

## Additional context

The [Mobility Data Management State of Practice](https://github.com/openmobilityfoundation/privacy-committee/wiki/Mobility-Data-Management-State-of-Practice) was developed by the OMF's Privacy, Security, and Transparency committee. It serves as a collection of policy and technical resources related to the handling and protection of MDS and other types of mobility data.
