### PR TITLE
provider: Fix a contradiction about the route localization

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -244,7 +244,7 @@ For the near-ish real time use cases, please use the [events](#events) endpoint.
 
 ### Routes
 
-To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route, even those which occur outside the [municipality boundary](#municipality-boundary).
+To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route, excepted those which occur outside the [municipality boundary](#municipality-boundary).
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS](https://en.wikipedia.org/wiki/Assisted_GPS) is accurate to 5 decimal places, [differential GPS](https://en.wikipedia.org/wiki/Differential_GPS) is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 


### PR DESCRIPTION
**Explain pull request**
I understand that choosing which option is still an ongoing discussion, in  #491 for instance.

Nevertheless, for now the current specification is contradictory:
- routes must be within city limits at some point
- route may not be within city limits 10 lines further

This PR enforces the most restrictive access for now: the route should be within a city boundary, as stated higher up in the document.

**Is this a breaking change**
Not really, since the specification is currently contradictory, it can't be implemented.

**Which spec(s) will this pull request impact?**
Provider