### PR TITLE
Updating references from 'master' to 'main'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-candidate.md
@@ -15,4 +15,4 @@ Please use this pull request to track Technology Council and OMF Board feedback 
 
 ### Action Item
 
-This pull request will be merged by an OMF maintainer after OMF Board Approval following the [Release Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/ReleaseGuidelines.md#making-a-release).
+This pull request will be merged by an OMF maintainer after OMF Board Approval following the [Release Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/ReleaseGuidelines.md#making-a-release).

--- a/.github/PULL_REQUEST_TEMPLATE/release-candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-candidate.md
@@ -15,4 +15,4 @@ Please use this pull request to track Technology Council and OMF Board feedback 
 
 ### Action Item
 
-This pull request will be merged by an OMF maintainer after OMF Board Approval following the [Release Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/ReleaseGuidelines.md#making-a-release).
+This pull request will be merged by an OMF maintainer after OMF Board Approval following the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md#making-a-release).

--- a/.github/PULL_REQUEST_TEMPLATE/release-final.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-final.md
@@ -15,4 +15,4 @@ This pull request will make the release official in `main`.
 
 ### Action Item
 
-Merge this pull request following the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md).
+Merge this pull request following the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md#making-a-release).

--- a/.github/PULL_REQUEST_TEMPLATE/release-final.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-final.md
@@ -11,8 +11,8 @@ assignees: jfh01
 
 The Release Candidate for MDS `X.Y.Z` has been approved: <https://github.com/openmobilityfoundation/mobility-data-specification/releases/tag/X.Y.Z-rc>
 
-This pull request will make the release official in `master`.
+This pull request will make the release official in `main`.
 
 ### Action Item
 
-Merge this pull request following the [Release Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/ReleaseGuidelines.md#making-a-release).
+Merge this pull request following the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-Particpation with the OMF is governed by the OMF's [Code of Conduct](https://github.com/openmobilityfoundation/governance/blob/master/CODE_OF_CONDUCT.md) and [Participation Policies](https://github.com/openmobilityfoundation/governance/raw/master/documents/OMFParticipationPolicies.pdf).
+Particpation with the OMF is governed by the OMF's [Code of Conduct](https://github.com/openmobilityfoundation/governance/blob/main/CODE_OF_CONDUCT.md) and [Participation Policies](https://github.com/openmobilityfoundation/governance/raw/main/documents/OMFParticipationPolicies.pdf).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # MDS Contributor Guidelines
 
-**See the new [MDS Contributor Guidelines](https://github.com/openmobilityfoundation/governance/blob/master/CONTRIBUTING.md) document for details.**
+**See the new [MDS Contributor Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/CONTRIBUTING.md) document for details.**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The specification will be versioned using Git tags and [semantic versioning](htt
 
 Information about the latest release and all releases are below. Please note, you may be viewing a development copy of the Mobility Data Specification based on the current branch. Info about the latest release and all releases is below.
 
-* [Latest Release](https://github.com/openmobilityfoundation/mobility-data-specification/tree/master)
+* [Latest Release](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main)
 
 * [All Releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can read more about the different APIs here: **[Understanding the different 
 ## Learn More / Get Involved / Contributing
 To stay up to date on MDS releases, meetings, and events, please **subscribe to the [mds-announce](https://groups.google.com/a/groups.openmobilityfoundation.org/forum/#!forum/mds-announce) mailing list.**
 
-The Mobility Data Specification is an open source project with all development taking place on GitHub. Comments and ideas can be shared by [creating an issue](https://github.com/openmobilityfoundation/mobility-data-specification/issues), and specific changes can be suggested by [opening a pull request](https://github.com/openmobilityfoundation/mobility-data-specification/pulls). Before contributing, please review our OMF [CONTRIBUTING page](https://github.com/openmobilityfoundation/governance/blob/master/CONTRIBUTING.md) to understand guidelines and policies for participation and our [CODE OF CONDUCT page](https://github.com/openmobilityfoundation/governance/blob/master/CODE_OF_CONDUCT.md).
+The Mobility Data Specification is an open source project with all development taking place on GitHub. Comments and ideas can be shared by [creating an issue](https://github.com/openmobilityfoundation/mobility-data-specification/issues), and specific changes can be suggested by [opening a pull request](https://github.com/openmobilityfoundation/mobility-data-specification/pulls). Before contributing, please review our OMF [CONTRIBUTING page](https://github.com/openmobilityfoundation/governance/blob/main/CONTRIBUTING.md) to understand guidelines and policies for participation and our [CODE OF CONDUCT page](https://github.com/openmobilityfoundation/governance/blob/main/CODE_OF_CONDUCT.md).
 
 You can learn more about the polices, methodolgies, and tools in the MDS ecosystem in the [Mobility Data Management State of Practice](https://github.com/openmobilityfoundation/privacy-committee/wiki/Mobility-Data-Management-State-of-Practice) wiki.
 
@@ -39,7 +39,7 @@ For questions about MDS please contact [info@openmobilityfoundation.org](mailto:
 
 ## Versions
 
-The specification will be versioned using Git tags and [semantic versioning](https://semver.org/). See prior [releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases) and the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/master/technical/ReleaseGuidelines.md) for more information.
+The specification will be versioned using Git tags and [semantic versioning](https://semver.org/). See prior [releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases) and the [Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md) for more information.
 
 Information about the latest release and all releases are below. Please note, you may be viewing a development copy of the Mobility Data Specification based on the current branch. Info about the latest release and all releases is below.
 

--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -2,5 +2,5 @@
 
 MDS will see regular updates and new [releases](https://github.com/openmobilityfoundation/mobility-data-specification/releases).
 
-**See the new [MDS Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/master/technical/ReleaseGuidelines.md) document for details.**
+**See the new [MDS Release Guidelines](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md) document for details.**
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -198,4 +198,4 @@ This release includes a number of enhancements and clarifications to the [`provi
 
 * MDS is under active development. As such, pre-`1.0` versions may introduce breaking changes until things stabilize. Every effort will be made to ensure that any breaking change is well documented and that appropriate workarounds are suggested.
 
-[provider]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/master/provider
+[provider]: https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/provider

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/get_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/get_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, GET vehicle payload",
   "type": "object",

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, register vehicle body",
   "type": "object",

--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_event.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle_event.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle status body",
   "type": "object",

--- a/agency/post_vehicle_telemetry.json
+++ b/agency/post_vehicle_telemetry.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle_telemetry.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle telemetry body",
   "type": "object",

--- a/provider/README.md
+++ b/provider/README.md
@@ -356,7 +356,7 @@ Without an `event_time` query parameter, `/status_changes` shall return a `400 B
 
 All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Compatibility with [GBFS 2.0](https://github.com/NABSA/gbfs/blob/v2.0/gbfs.md) or greater is advised due to privacy concerns and support for micromobility.
 
-GBFS 2.0 includes some changes that may make it less useful for regulatory purposes (specifically, the automatic rotation of vehicle IDs). The [`/vehicles`](#vehicles) endpoint offers an alternative to GBFS that may more effectively meet the use cases of regulators. Additional information on MDS and GBFS can be found in this [guidance document](https://github.com/openmobilityfoundation/governance/blob/master/technical/GBFS_and_MDS.md).
+GBFS 2.0 includes some changes that may make it less useful for regulatory purposes (specifically, the automatic rotation of vehicle IDs). The [`/vehicles`](#vehicles) endpoint offers an alternative to GBFS that may more effectively meet the use cases of regulators. Additional information on MDS and GBFS can be found in this [guidance document](https://github.com/openmobilityfoundation/governance/blob/main/technical/GBFS_and_MDS.md).
 
 ### Events
 

--- a/provider/auth.md
+++ b/provider/auth.md
@@ -36,4 +36,4 @@ If an MDS `provider` implements this auth scheme, it **MAY** choose to specify t
 
 The `/trips` and `/status_changes` endpoints may or may not require authentication, it is up to the implementing provider to decide if they want historical information available with or without authentication. 
 
-As of MDS 0.3.0, `gbfs.json` is required. The required GBFS endpoints should be made available publicly. See [#realtime-data](https://github.com/openmobilityfoundation/mobility-data-specification/tree/master/provider#realtime-data) for more information about how to implement GBFS for dockless systems. 
+As of MDS 0.3.0, `gbfs.json` is required. The required GBFS endpoints should be made available publicly. See [#realtime-data](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/provider#realtime-data) for more information about how to implement GBFS for dockless systems. 

--- a/provider/dockless/events.json
+++ b/provider/dockless/events.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/events.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/events.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, events payload",
   "type": "object",

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/vehicles.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/vehicles.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, vehicles payload",
   "type": "object",

--- a/schema/templates/agency/get_vehicle.json
+++ b/schema/templates/agency/get_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/get_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/get_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, GET vehicle payload",
   "type": "object",

--- a/schema/templates/agency/post_vehicle.json
+++ b/schema/templates/agency/post_vehicle.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, register vehicle body",
   "type": "object",

--- a/schema/templates/agency/post_vehicle_event.json
+++ b/schema/templates/agency/post_vehicle_event.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_event.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle_event.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle status body",
   "type": "object",

--- a/schema/templates/agency/post_vehicle_telemetry.json
+++ b/schema/templates/agency/post_vehicle_telemetry.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/agency/post_vehicle_telemetry.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/agency/post_vehicle_telemetry.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, POST vehicle telemetry body",
   "type": "object",

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/schema/templates/common.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/schema/templates/common.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, common definitions",
   "type": "object",

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/status_changes.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/status_changes.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, status_change payload",
   "type": "object",

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/trips.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/trips.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, trips payload",
   "type": "object",

--- a/schema/templates/provider/vehicles.json
+++ b/schema/templates/provider/vehicles.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/vehicles.json",
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/main/provider/dockless/vehicles.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Provider Schema, vehicles payload",
   "type": "object",


### PR DESCRIPTION
Per issue [#7](https://github.com/openmobilityfoundation/governance/issues/7) in the Governance repo, this PR finds all mentions of "master" in the `dev` branch and replaces it with "main".  