### PR TITLE
Agency/telemetry: add `unregistered` error

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -225,11 +225,12 @@ Body Params:
 
 400 Failure Response:
 
-| `error`         | `error_description`                  | `error_details`[]               |
-| --------------- | ------------------------------------ | ------------------------------- |
-| `bad_param`     | A validation error occurred.         | Array of parameters with errors |
-| `invalid_data`  | None of the provided data was valid. |                                 |
-| `missing_param` | A required parameter is missing.     | Array of missing parameters     |
+| `error`         | `error_description`                  | `error_details`[]                 |
+| --------------- | ------------------------------------ | --------------------------------- |
+| `bad_param`     | A validation error occurred.         | Array of parameters with errors   |
+| `invalid_data`  | None of the provided data was valid. |                                   |
+| `missing_param` | A required parameter is missing.     | Array of missing parameters       |
+| `unregistered`  | Some of the devices are unregistered | Array of unregistered `device_id` |
 
 [Top][toc]
 


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

As an agency, when receiving a batch of telemetry data including unregistered devices, there is currently no official way to let the provider know why the corresponding telemetries were rejected. This makes it complicated for the provider to automate the detection and resolution of this problem.

### Describe the solution you'd like

Adapt the `unregistered` error existing in the Agency/event endpoint to Agency/telemetry.

### Is this a breaking change

No, not breaking : we are just adding a new error type. 

### Impacted Spec

For which spec is this feature being requested?

 * `agency`

### Describe alternatives you've considered

The current workaround we are using is to return a bad_param error on parameter `device_id`, Listing the unregistered ids in the error description: `A validation error occured. Unregistered devices: UUID1, UUID2, etc.`.

### Additional context

Add any other context or screenshots about the feature request here.
