### PR TITLE
Add retire_date as an optional field to Geography

### DIFF
--- a/geography/README.md
+++ b/geography/README.md
@@ -105,6 +105,7 @@ Placeholder -- link to schema to be added later.
 | `effective_date`   | [timestamp][ts] | Optional   | The date at which a Geography is considered "live".  Must be at or after `publish_date`. |
 | `publish_date`     | [timestamp][ts] | Required   | Time that the geography was published, i.e. made immutable                       |
 | `prev_geographies` | UUID[]    | Optional   | Unique IDs of prior geographies replaced by this one                                   |
+| `retire_date` | [timestamp][ts] | Optional | The date at which a Geography is no longer considered "live".  Must be after `effective_date`. |
 
 [Top][toc]
 


### PR DESCRIPTION
## Explain pull request

Add a retire_date field to allow cities to specify when a geography is no longer active.

## Is this a breaking change

* No, not breaking


## Impacted Spec

Which spec(s) will this pull request impact?

* `geography`

## Additional context

As discussed in the [10/20 Provider WG meeting](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-conference-notes,-2020.10.08-(Joint-Working-Group-Provider-Services)#minutes), adding a retire_date field will allow cities to indicate when a geography isn't used anymore.  While the prev_geographies field allows this functionality, it requires cities to maintain that relationship, which they may not do.  Additionally, some geographies might be considered inactive without a new geography to replace them (e.g., a special event zone).