### PR TITLE
Stops Updates for Release

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -195,6 +195,8 @@ Stops describe vehicle trip start and end locations in a pre-designated physical
 | num_places_disabled    | {vehicle_type: number}                                      | Optional          | How many places are disabled and unable to accept vehicles at this stop?                     |
 | parent_stop            | UUID                                                        | Optional          | Describe a basic hierarchy of stops (e.g.a stop inside of a greater stop)                    |
 | devices               | UUID[]                                                      | Optional          | List of device_ids for vehicles which are currently at this stop                             |
+| image_url               | URL                                                      | Optional          | Link to an image, photo, or diagram of the stop. Could be used by providers to help riders find or use the stop.                            |
+
 
 ### Stop Status
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -248,7 +248,6 @@ An individual `Rule` object is defined by the following fields:
 | `days`             | day[]                       | Optional   | Days `["sun", "mon", "tue", "wed", "thu", "fri", "sat"]` when the rule is in effect (default all) |
 | `messages`         | `{ String:String }`         | Optional   | Message to rider user, if desired, in various languages, keyed by language tag (see [Messages](#messages)) |
 | `value_url`        | URL                         | Optional   | URL to an API endpoint that can provide dynamic information for the measured value (see [Value URL](#value-url)) |
-| `stops`      | UUID[]                      | Optional   | List of [Stop](/general-information.md#stops) UUIDs that this Rule applies to. If this field is used then the `geographies` field must be used to identify the locations.  |
 
 [Top][toc]
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -248,6 +248,7 @@ An individual `Rule` object is defined by the following fields:
 | `days`             | day[]                       | Optional   | Days `["sun", "mon", "tue", "wed", "thu", "fri", "sat"]` when the rule is in effect (default all) |
 | `messages`         | `{ String:String }`         | Optional   | Message to rider user, if desired, in various languages, keyed by language tag (see [Messages](#messages)) |
 | `value_url`        | URL                         | Optional   | URL to an API endpoint that can provide dynamic information for the measured value (see [Value URL](#value-url)) |
+| `stops`      | UUID[]                      | Optional   | List of [Stop](/general-information.md#stops) UUIDs that this Rule applies to. If this field is used then the `geographies` field must be used to identify the locations.  |
 
 [Top][toc]
 

--- a/policy/examples/README.md
+++ b/policy/examples/README.md
@@ -11,6 +11,7 @@ This file presents a series of example [Policy documents](../README.md#schema) f
 - [Per Trip Fees](#per-trip-fees)
 - [Vehicle Right of Way Fees](#vehicle-right-of-way-fees)
 - [Metered Parking Fees](#metered-parking-fees)
+- [Required Parking](#required-parking)
 
 ## Prohibited Zone
 
@@ -384,3 +385,65 @@ File: [`metered-parking-fees.json`](metered-parking-fees.json)
 ```
 
 [Top](#table-of-contents)
+
+## Required Parking
+
+This policy states that within the downtown region, parking of scooters and bicycles must take place within specific geographies.
+
+File: [`required-parking.json`](required-parking.json)
+
+```json
+{
+  "policy_id": "99f7a469-6e3a-4981-9313-c2f6c0bbd5ce",
+  "name": "Test City Mobility Hubs",
+  "description": "Enforced parking in specific mobility hubs for downtown area",
+  "start_date": 1558389669540,
+  "end_date": null,
+  "published_date": 1558389669540,
+  "prev_policies": null,
+  "rules": [
+    {
+      "name": "Allow parking in specific locations",
+      "rule_id": "8a61de66-d9fa-4cba-a38d-5d948e2373fe",
+      "minimum": 0,
+      "rule_type": "count",
+      "rule_units": "devices",
+      "geographies": [
+        "e3ed0a0e-61d3-4887-8b6a-4af4f3769c14",
+        "1512a3f4-313c-45fc-9fae-0dca6d7ab355"
+      ],
+      "states": {
+        "available": [
+          "trip_end"
+        ]
+      },
+      "vehicle_types": [
+        "bicycle",
+        "scooter"
+      ]
+    },
+    {
+      "name": "Disallow parking elsewhere in downtown area",
+      "rule_id": "0240899e-a8ad-4263-953a-6e278ff859ab",
+      "rule_type": "count",
+      "maximum": 0,
+      "rule_units": "devices",
+      "geographies": [
+        "075a5303-2571-4ca5-b429-841bcc4025d1"
+      ],
+      "states": {
+        "available": [
+          "trip_end"
+        ]
+      },
+      "vehicle_types": [
+        "bicycle",
+        "scooter"
+      ]
+    }
+  ]
+}
+```
+
+[Top](#table-of-contents)
+

--- a/policy/examples/required-parking.json
+++ b/policy/examples/required-parking.json
@@ -1,0 +1,58 @@
+{
+  "updated": 0,
+  "version": "1.0.0",
+  "data": {
+    "policy": [
+      {
+        "policy_id": "99f7a469-6e3a-4981-9313-c2f6c0bbd5ce",
+        "name": "Test City Mobility Hubs",
+        "description": "Enforced parking in specific mobility hubs for downtown area",
+        "start_date": 1558389669540,
+        "end_date": null,
+        "published_date": 1558389669540,
+        "prev_policies": null,
+        "rules": [
+          {
+            "name": "Allow parking in specific locations",
+            "rule_id": "8a61de66-d9fa-4cba-a38d-5d948e2373fe",
+            "minimum": 0,
+            "rule_type": "count",
+            "rule_units": "devices",
+            "geographies": [
+              "e3ed0a0e-61d3-4887-8b6a-4af4f3769c14",
+              "1512a3f4-313c-45fc-9fae-0dca6d7ab355"
+            ],
+            "states": {
+              "available": [
+                "trip_end"
+              ]
+            },
+            "vehicle_types": [
+              "bicycle",
+              "scooter"
+            ]
+          },
+          {
+            "name": "Disallow parking elsewhere in downtown area",
+            "rule_id": "0240899e-a8ad-4263-953a-6e278ff859ab",
+            "rule_type": "count",
+            "maximum": 0,
+            "rule_units": "devices",
+            "geographies": [
+              "075a5303-2571-4ca5-b429-841bcc4025d1"
+            ],
+            "states": {
+              "available": [
+                "trip_end"
+              ]
+            },
+            "vehicle_types": [
+              "bicycle",
+              "scooter"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Consolidated updates to stops from the community across a few issues and discussions:

- Stops in policy - Add optional stops to rules (like geographies). If stops then geography ID required. #554
- Required stops example addition using current policy rules #554
- Optional stops image #555

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`
* `policy`
* `provider`

