### PR TITLE
Geographic Updates for Release

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -92,7 +92,7 @@ represented as a GeoJSON [`Feature`][geojson-feature] object with a correspondin
 
 ### Stop-based Geographic Data
 
-When an individual location coordinate measurement corresponds to a [Stop][general-stops],
+When an individual location coordinate (Point, MultiPolygon, etc.) corresponds to a [Stop][general-stops],
 it must be presented with a `stop_id` property:
 
 ```json
@@ -178,7 +178,7 @@ Stops describe vehicle trip start and end locations in a pre-designated physical
 | stop_id                | UUID                                                        | Required          | Unique ID for stop                                                                           |
 | name              | String                                                      | Required          | Name of stop                                                                                 |
 | last_reported          | Timestamp                                                   | Required          | Date/Time that the stop was last updated                                                     |
-| location               | GeoJSON [Point Feature](provider/README.md#geographic-data) | Required          | Location of the Stop                                                                         |
+| location               | GeoJSON [Point or Polygon Feature](provider/README.md#geographic-data) | Required          | Location of the Stop. If Point is used then assume a 20 meter buffer.                                                                         |
 | status                 | [Stop Status](#stop-status)                                 | Required          | Object representing the status of the Stop. See [Stop Status](#stop-status).                 |
 | capacity               | {vehicle_type: number}                                      | Required          | Number of total places per vehicle_type                                                      |
 | num_vehicles_available | {vehicle_type: number}                                      | Required          | How many vehicles are available per vehicle_type at this stop?                               |

--- a/general-information.md
+++ b/general-information.md
@@ -92,8 +92,7 @@ represented as a GeoJSON [`Feature`][geojson-feature] object with a correspondin
 
 ### Stop-based Geographic Data
 
-When an individual location coordinate (Point, MultiPolygon, etc.) corresponds to a [Stop][general-stops],
-it must be presented with a `stop_id` property:
+When an individual location coordinate measurement (Point) corresponds to a [Stop][general-stops], it must be presented with a `stop_id` property:
 
 ```json
 {
@@ -176,15 +175,15 @@ Stops describe vehicle trip start and end locations in a pre-designated physical
 | Field                  | Type                                                        | Required/Optional | Description                                                                                  |
 |------------------------|-------------------------------------------------------------|-------------------|----------------------------------------------------------------------------------------------|
 | stop_id                | UUID                                                        | Required          | Unique ID for stop                                                                           |
-| name              | String                                                      | Required          | Name of stop                                                                                 |
+| name                   | String                                                      | Required          | Name of stop                                                                                 |
 | last_reported          | Timestamp                                                   | Required          | Date/Time that the stop was last updated                                                     |
-| location               | GeoJSON [Point or Polygon Feature](provider/README.md#geographic-data) | Required          | Location of the Stop. If Point is used then assume a 20 meter buffer.                                                                         |
+| location               | GeoJSON [Point Feature](#stop-based-geographic-data) | Required          | Simple centerpoint location of the Stop. The use of the optional `geography_id` is recommended to provide more detail.                                                                         |
 | status                 | [Stop Status](#stop-status)                                 | Required          | Object representing the status of the Stop. See [Stop Status](#stop-status).                 |
 | capacity               | {vehicle_type: number}                                      | Required          | Number of total places per vehicle_type                                                      |
 | num_vehicles_available | {vehicle_type: number}                                      | Required          | How many vehicles are available per vehicle_type at this stop?                               |
 | num_vehicles_disabled  | {vehicle_type: number}                                      | Required          | How many vehicles are unavailable/reserved per vehicle_type at this stop?                    |
 | provider_id            | UUID                                                        | Optional          | UUID for the Provider managing this stop. Null/undefined if managed by an Agency.  See MDS [provider list](/providers.csv).  |
-| geography_id           | UUID                                                        | Optional          | Pointer to the [Geography](/geography) that represents the Stop geospatially                               |
+| geography_id           | UUID                                                        | Optional          | Pointer to the [Geography](/geography) that represents the Stop geospatially via Polygon or MultiPolygon.                               |
 | region_id              | string                                                      | Optional          | ID of the region where station is located, see [GBFS Station Information][gbfs-station-info] |
 | short_name             | String                                                      | Optional          | Abbreviated stop name                                                                        |
 | address                | String                                                      | Optional          | Postal address (useful for directions)                                                       |

--- a/general-information.md
+++ b/general-information.md
@@ -69,7 +69,7 @@ Additionally, `device_id` must remain constant for the device's lifetime of serv
 
 ## Geographic Data
 
-References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)][wgs84] standard GPS or GNSS projection expressed as [Decimal Degrees][decimal-degrees].
+References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)][wgs84] standard GPS or GNSS projection expressed as [Decimal Degrees][decimal-degrees]. When points are used, you may assume a 20 meter buffer around the point when needed.
 
 Whenever an individual location coordinate measurement is presented, it must be
 represented as a GeoJSON [`Feature`][geojson-feature] object with a corresponding [`timestamp`][ts] property and [`Point`][geojson-point] geometry:

--- a/geography/README.md
+++ b/geography/README.md
@@ -51,7 +51,7 @@ This temporary requirement is to ensure backwards compatibility, but the overall
 
 Geographies shall be published by regulatory agencies or their authorized delegates as JSON objects. These JSON objects shall be served by either [flat files](#flat-files) or via [REST API endpoints](#rest-endpoints). In either case, geography data shall follow the [schema](#schema) outlined below.
 
-Published geographies, should be treated as immutable data. Obsoleting or otherwise changing a geography is accomplished by publishing a new geography with a field named `prev_geographies`, a list of UUID references to the geography or policies geographies by the new geography.
+Published geographies, should be treated as immutable data. Obsoleting or otherwise changing a geography is accomplished by publishing a new geography with a field named `prev_geographies`, a list of UUID references to the geography or policies geographies by the new geography. Note adding `retire_date` once is allowed without the need for a new `geography_id`.
 
 Geographical data shall be represented as GeoJSON `Feature` objects. Typically no part of the geographical data should be outside the [municipality boundary][muni-boundary] unless an agency has the authority to regulate there.
 
@@ -104,6 +104,7 @@ Placeholder -- link to schema to be added later.
 | `geography_json`   | UUID      | Required   | The GeoJSON that defines the geographical coordinates.                                 |
 | `effective_date`   | [timestamp][ts] | Optional   | The date at which a Geography is considered "live".  Must be at or after `published_date`. |
 | `published_date`     | [timestamp][ts] | Required   | Time that the geography was published, i.e. made immutable                       |
+| `retire_date`     | [timestamp][ts] | Optional   | Time that the geography is slated to retire, i.e. be no longer usable. Note add this does not require creating a new `geography_id`, eg, it does not affect immutability.                       |
 | `prev_geographies` | UUID[]    | Optional   | Unique IDs of prior geographies replaced by this one                                   |
 
 [Top][toc]

--- a/geography/README.md
+++ b/geography/README.md
@@ -123,11 +123,7 @@ Type of geography. These specific types are recommendations based on ones common
 | Value                | Description                          |
 | -----                | -----------                          |
 | `municipal_boundary` | Edge of a city                       |
-| `operating_area`     | Vehicle permitted operating area     |
-| `distribution_zone`  | An area of interest for distribution |
-| `no_ride_zone`       | Areas where riding is not permitted  |
-| `no_parking_zone`    | Areas where parking is not permitted |
-| `slow_ride_zone`     | Areas where top speed is reduced     |
+| `policy_zone`        | Zone where [Policy](/policy) rules could be in effect, like operating area, distribution/equity zones, no/slow ride zone, no parking, etc |
 | `county_boundary`    | Edge of a county                     |
 | `stop`               | See [Stops](stops)                   |
 | `council_district`   | City council district                |

--- a/geography/README.md
+++ b/geography/README.md
@@ -104,7 +104,7 @@ Placeholder -- link to schema to be added later.
 | `geography_json`   | UUID      | Required   | The GeoJSON that defines the geographical coordinates.                                 |
 | `effective_date`   | [timestamp][ts] | Optional   | The date at which a Geography is considered "live".  Must be at or after `published_date`. |
 | `published_date`     | [timestamp][ts] | Required   | Time that the geography was published, i.e. made immutable                       |
-| `retire_date`     | [timestamp][ts] | Optional   | Time that the geography is slated to retire, i.e. be no longer usable. Note add this does not require creating a new `geography_id`, eg, it does not affect immutability.                       |
+| `retire_date`     | [timestamp][ts] | Optional   | Time that the geography is slated to retire, i.e. be no longer usable. Note add this does not require creating a new `geography_id`, eg, it does not affect immutability.  Must be after `effective_date`.                     |
 | `prev_geographies` | UUID[]    | Optional   | Unique IDs of prior geographies replaced by this one                                   |
 
 [Top][toc]

--- a/geography/README.md
+++ b/geography/README.md
@@ -125,7 +125,7 @@ Type of geography. These specific types are recommendations based on ones common
 | `municipal_boundary` | Edge of a city                       |
 | `policy_zone`        | Zone where [Policy](/policy) rules could be in effect, like operating area, distribution/equity zones, no/slow ride zone, no parking, etc |
 | `county_boundary`    | Edge of a county                     |
-| `stop`               | See [Stops](stops)                   |
+| `stop`               | See [Stops](/general-information.ms#stops)                   |
 | `council_district`   | City council district                |
 | `political_district` | Politically defined voting area      |
 | `neighborhood`       | Neighborhood area                    |

--- a/geography/README.md
+++ b/geography/README.md
@@ -51,7 +51,7 @@ This temporary requirement is to ensure backwards compatibility, but the overall
 
 Geographies shall be published by regulatory agencies or their authorized delegates as JSON objects. These JSON objects shall be served by either [flat files](#flat-files) or via [REST API endpoints](#rest-endpoints). In either case, geography data shall follow the [schema](#schema) outlined below.
 
-Published geographies, should be treated as immutable data. Obsoleting or otherwise changing a geography is accomplished by publishing a new geography with a field named `prev_geographies`, a list of UUID references to the geography or policies geographies by the new geography. Note adding `retire_date` once is allowed without the need for a new `geography_id`.
+Published geographies, should be treated as immutable data. Obsoleting or otherwise changing a geography is accomplished by publishing a new geography with a field named `prev_geographies`, a list of UUID references to the geography or policies geographies by the new geography.
 
 Geographical data shall be represented as GeoJSON `Feature` objects. Typically no part of the geographical data should be outside the [municipality boundary][muni-boundary] unless an agency has the authority to regulate there.
 
@@ -104,7 +104,7 @@ Placeholder -- link to schema to be added later.
 | `geography_json`   | UUID      | Required   | The GeoJSON that defines the geographical coordinates.                                 |
 | `effective_date`   | [timestamp][ts] | Optional   | The date at which a Geography is considered "live".  Must be at or after `published_date`. |
 | `published_date`     | [timestamp][ts] | Required   | Time that the geography was published, i.e. made immutable                       |
-| `retire_date`     | [timestamp][ts] | Optional   | Time that the geography is slated to retire, i.e. be no longer usable. Note add this does not require creating a new `geography_id`, eg, it does not affect immutability.  Must be after `effective_date`.                     |
+| `retire_date`     | [timestamp][ts] | Optional   | Time that the geography is slated to retire. Once the retire date is passed, new policies can no longer reference it and old policies referencing it should be updated. Retired geographies should continue to be returned in the geographies list. Must be after `effective_date`. |
 | `prev_geographies` | UUID[]    | Optional   | Unique IDs of prior geographies replaced by this one                                   |
 
 [Top][toc]


### PR DESCRIPTION
## Explain pull request

Addressing multiple Issues and conversations around geographic parts of the release and /geography:

- Roll policy types into new geo type (geofence/policy_zone) #588 
- Retire date optional #590 
- Allowing  Polygons - Need to clarify no points or specify in spec a buffer around any points. Geographic data in general info - polygon. Point in route for stop. Connect to geography for stop as a feature collection. Change example from point to polygons for stops in Geography. Change location field to describe polygon or point (just point now).  
 
## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`
* `policy`
* `provider`

