### PR TITLE
Provider Reports - API

### DIFF
--- a/geography/README.md
+++ b/geography/README.md
@@ -99,7 +99,7 @@ Placeholder -- link to schema to be added later.
 | ----------------   | --------- | --- | --------------------------------------------------------------------------------------------- |
 | `name`             | String    | Required   | Name of geography                                                                      |
 | `description`      | String    | Optional   | Detailed description of geography                                                      |
-| `geography_type`   | Sting     | Optional   | Type of geography, e.g. `municipal_boundary` or `council_district` or custom text.  See [Geography Types](#geography-types). |
+| `geography_type`   | String    | Optional   | Type of geography, e.g. `municipal_boundary` or `council_district` or custom text.  See [Geography Types](#geography-types). |
 | `geography_id`     | UUID      | Required   | Unique ID of geography                                                                 |
 | `geography_json`   | UUID      | Required   | The GeoJSON that defines the geographical coordinates.                                 |
 | `effective_date`   | [timestamp][ts] | Optional   | The date at which a Geography is considered "live".  Must be at or after `published_date`. |

--- a/metrics/core_metrics.md
+++ b/metrics/core_metrics.md
@@ -41,7 +41,6 @@ The following represent the suggested MDS core metric dimensions:
 | provider_id        | Transportation provider id issued by OMF and [tracked here](/providers.csv) |
 | geography_id       | [MDS Geography](/geography)                                                 |
 | vehicle_type       | [Vehicle Type](/agency#vehicle-type) defined by MDS                         |
-| special_group_type | [Special Group Type](#special-group-type) defined by MDS                    |
 
 [Top][toc]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -23,7 +23,7 @@ This specification contains a data standard for *mobility as a service* provider
 * [Reports](#reports)
   * [Reports - Response](#reports---response)
   * [Reports - Response Schema](#reports---response-schema)
-  * [Reports - Query Parameters](#reports---query-parameters)
+  * [Reports - Query Parameters](#reports---parameters)
   * [Reports - Dimensions](#reports---dimensions)
   * [Data Redaction](#data-redaction)
 * [Realtime Data](#realtime-data)

--- a/provider/README.md
+++ b/provider/README.md
@@ -20,6 +20,11 @@ This specification contains a data standard for *mobility as a service* provider
   * [Routes](#routes)
 * [Status Changes][status]
   * [Status Changes - Query Parameters](#status-changes---query-parameters)
+* [Reports][#reports]
+  * [Reports - Response](#reports---response)
+  * [Reports - Response Schema](#reports---response-schema)
+  * [Reports - Query Parameters](#reports---query-parameters)
+  * [Data Redaction](#data-redaction)
 * [Realtime Data](#realtime-data)
   * [GBFS](#GBFS)
   * [Data Latency Requirements][data-latency]
@@ -288,6 +293,40 @@ If the requested hour occurs in a time period in which the provider was not oper
 or the hour is not yet in the past `/status_changes` shall return a `404 Not Found` error.
 
 Without an `event_time` query parameter, `/status_changes` shall return a `400 Bad Request` error.
+
+[Top][toc]
+
+## Reports
+
+Reports are information that providers can send back to agencies containing aggregated information of data that is not contained within other MDS endpoints.
+
+The authenticated reports endpoint allows a user to pass in some parameters and get trip counts in the response.
+
+### Response
+
+**Endpoint:** `/reports`  
+**Method:** `GET`  
+**[Beta feature][beta]:** Yes (as of 1.1.0)  
+**Schema:** TBD when out of beta  
+**`data` Payload:** `{ "reports": [] }`, an array of objects with the following structure  
+
+TBD
+
+### Response Schema
+
+TBD
+
+### Parameters
+
+TBD
+
+### Data Redaction
+
+Some combinations of parameters may return a small count of trips, which could increase a privacy risk of re-identification. To correct for that, Reports does not return data below a certain count of results. This is called k-anonymity, and the threshold is set at a k-value of 10.
+
+If the query returns less than 10 trips in its count, then a rows value number of -1 is returned.
+
+The k-value used is always returned in the `/reports` endpoint response to provide important context for the data consumer on the data redaction that is occuring.
 
 [Top][toc]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -299,7 +299,7 @@ Without an `event_time` query parameter, `/status_changes` shall return a `400 B
 
 ## Reports
 
-Reports are information that providers can send back to agencies containing aggregated information of data that is not contained within other MDS endpoints, like counts of special groups.
+Reports are information that providers can send back to agencies containing aggregated data that is not contained within other MDS endpoints, like counts of special groups.
 
 The authenticated reports endpoint allows a user to pass in some parameters and get trip counts in the response.
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -383,7 +383,7 @@ Other special group types may be added in future MDS releases as relevant agency
 #### Request
 
 ```js
-POST /reports
+GET /reports
 {
   "start_date": "2019-07-01T00:00-07",
   "end_date": "2019-12-31T00:00-07",


### PR DESCRIPTION
## Explain pull request

This is a simplified, beta implementation of the #569 special groups aggregate metrics issue.  It adds a /reports endpoint within the Provider API that handles returning monthly trip counts of special groups, in this case just low income groups.

The structure is similar to the Metrics API, but reduced in scope (no duration specifications, no measures besides counts of trips).  

## Is this a breaking change

* No, not breaking (new feature)

## Impacted Spec

Which spec(s) will this pull request impact?

* `provider`

## Additional context

Measures and durations could be added back into the PR. See PR #607 for a static version of this solution.
