### PR TITLE
Add minimal value to all timestamp json definition

### DIFF
--- a/agency/get_stops.json
+++ b/agency/get_stops.json
@@ -156,7 +156,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -30,7 +30,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/agency/post_stops.json
+++ b/agency/post_stops.json
@@ -156,7 +156,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -80,7 +80,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/agency/post_vehicle_telemetry.json
+++ b/agency/post_vehicle_telemetry.json
@@ -80,7 +80,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/policy/policy.json
+++ b/policy/policy.json
@@ -377,7 +377,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/events.json
+++ b/provider/events.json
@@ -20,7 +20,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -20,7 +20,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/stops.json
+++ b/provider/stops.json
@@ -20,7 +20,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -20,7 +20,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/vehicles.json
+++ b/provider/vehicles.json
@@ -20,7 +20,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -380,7 +380,7 @@
       "type": "number",
       "description": "Integer milliseconds since Unix epoch",
       "multipleOf": 1.0,
-      "minimum": 0
+      "minimum": 1514764800000
     },
     "trip_id_reference": {
       "description": "Conditionally require a trip_id reference",


### PR DESCRIPTION
The goal is to prevent the easy to make mistake of using a second
timestamp instead of a millisecond timestamp.

This PR implements issue #645 
