### PR TITLE
Add a rate_applies_when field to Policy Rules

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -10,7 +10,7 @@ This specification describes the digital relationship between _mobility as a ser
 
 - [General Information](#general-information)
   - [Versioning](#versioning)
-  - [Update Frequency](#update-frequency)  
+  - [Update Frequency](#update-frequency)
 - [Background](#background)
 - [Distribution](#distribution)
 - [REST Endpoints](#rest-endpoints)
@@ -37,7 +37,7 @@ This specification describes the digital relationship between _mobility as a ser
     - [Programs](#requirement-programs)
     - [Data Specs](#requirement-data-specs)
     - [APIs](#requirement-apis)
- 
+
 ## General information
 
 The following information applies to all `policy` API endpoints.
@@ -117,8 +117,8 @@ Authorization is not required. An agency may decide to make this endpoint unauth
 
 ### Policies
 
-Endpoint: `/policies/{id}`  
-Method: `GET`  
+Endpoint: `/policies/{id}`
+Method: `GET`
 `data` Payload: `{ "policies": [] }`, an array of objects with the structure [outlined below](#policy).
 
 #### Query Parameters
@@ -139,8 +139,8 @@ Policies will be returned in order of effective date (see schema below), with pa
 
 **Deprecated:** see the new [Geography API](/geography#transition-from-policy) to understand the transistion away from this endpoint, and how to support both in a MDS 1.x.0 release.
 
-Endpoint: `/geographies/{id}`  
-Method: `GET`  
+Endpoint: `/geographies/{id}`
+Method: `GET`
 `data` Payload: `{ geographies: [] }`, an array of GeoJSON `Feature` objects that follow the schema [outlined here](#geography) or in [Geography](/geography#general-information).
 
 #### Query Parameters
@@ -153,9 +153,9 @@ Method: `GET`
 
 ### Requirements
 
-Endpoint: `/requirements/`  
-Method: `GET`  
-`data` Payload: `{ requirements: [] }`, JSON objects that follow the schema [outlined here](#requirement).  
+Endpoint: `/requirements/`
+Method: `GET`
+`data` Payload: `{ requirements: [] }`, JSON objects that follow the schema [outlined here](#requirement).
 [Beta feature](/general-information.md#beta-features): *Yes (as of 1.2.0)*. [Leave feedback](https://github.com/openmobilityfoundation/mobility-data-specification/issues/682)
 
 See [Policy Requirements Examples](/policy/examples/requirements.md) for how this can be implemented.
@@ -279,8 +279,9 @@ An individual `Rule` object is defined by the following fields:
 | `maximum`          | integer                     | Optional   | Maximum value, if applicable (default unlimited) |
 | `rate_amount`      | integer                     | Optional   | Amount of the rate (see [Rate Amounts](#rate-amounts)) |
 | `rate_recurrence`  | enum                        | Optional   | Recurrence of the rate (see [Rate Recurrences](#rate-recurrences)) |
-| `start_time`       | ISO 8601 time `hh:mm:ss`              | Optional   | Beginning time-of-day when the rule is in effect (default 00:00:00). |
-| `end_time`         | ISO 8601 time `hh:mm:ss`              | Optional   | Ending time-of-day when the rule is in effect (default 23:59:59). |
+| `rate_applies_when` | enum                       | Optional   | Specifies when a rate is applied to a rule (see [Rate Applies When](#rate-applies-when)) (defaults to `out_of_bounds`) |
+| `start_time`       | ISO 8601 time `hh:mm:ss`    | Optional   | Beginning time-of-day when the rule is in effect (default 00:00:00). |
+| `end_time`         | ISO 8601 time `hh:mm:ss`    | Optional   | Ending time-of-day when the rule is in effect (default 23:59:59). |
 | `days`             | day[]                       | Optional   | Days `["sun", "mon", "tue", "wed", "thu", "fri", "sat"]` when the rule is in effect (default all) |
 | `messages`         | `{ String:String }`         | Optional   | Message to rider user, if desired, in various languages, keyed by language tag (see [Messages](#messages)) |
 | `value_url`        | URL                         | Optional   | URL to an API endpoint that can provide dynamic information for the measured value (see [Value URL](#value-url)) |
@@ -340,16 +341,29 @@ The amount of a rate applied when this rule applies, if applicable (default zero
 
 #### Rate Recurrences
 
-Rate recurrences specify when a rate is applied – either once, or periodically according to a `time_unit` specified using [Rule Units](#rule-units). A `time_unit` refers to a unit of time as measured in local time for the jurisdiction – a day begins at midnight local time, an hour begins at the top of the hour, etc.
+Rate recurrences specify how a rate is applied – either once, or periodically according to a `time_unit` specified using [Rule Units](#rule-units). A `time_unit` refers to a unit of time as measured in local time for the jurisdiction – a day begins at midnight local time, an hour begins at the top of the hour, etc.
 
 | Name                        | Description                                                                                                                                                       |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `once_on_match`             | Rate is applied once when a vehicle transitions **into** a matching status from a non-matching status.                                                            |
-| `once_on_unmatch`           | Rate is applied once a vehicle transitions **out of** a matching status to a non-matching status.                                                                 | 
-| `each_time_unit`            | During each `time_unit`, rate is applied once to vehicles entering or remaining in a matching status. Requires a `time_unit` to be specified using `rule_units`.  |  
+| `once_on_unmatch`           | Rate is applied once a vehicle transitions **out of** a matching status to a non-matching status.                                                                 |
+| `each_time_unit`            | During each `time_unit`, rate is applied once to vehicles entering or remaining in a matching status. Requires a `time_unit` to be specified using `rule_units`.  |
 | `per_complete_time_unit`    | Rate is applied once per complete `time_unit` that vehicles remain in a matching status. Requires a `time_unit` to be specified using `rule_units`.               |
 
 [Top][toc]
+
+#### Rate Applies When
+
+The `rate_applies_when` field specifies when a rate should be applied to an event or count,
+e.g. is it when the event is within the Rule bounds or when it is outside?
+It defaults to `out_of_bounds`.
+
+The `rate_applies_when` field may take the following values:
+
+| Name            | Description |
+| --------------- | ----------- |
+| `in_bounds`     | Rate applies when an event or count is within the rule `minimum` and `maximum` |
+| `out_of_bounds` | Rate applies when an event or count is outside of the rule `minimum` and `maximum` |
 
 ### Messages
 
@@ -420,14 +434,14 @@ Note that while Requirements is in [beta](#Requirements) in this **minor**, non-
 
 #### Requirement Format
 
-An agency's program [Requirements](#requirements) endpoint contains a number of distinct parts, namely [metadata](#requirement-metadata), [program definitions](#requirement-programs), and [data specs](#requirement-data-specs) (with sub sections on relevant [required APIs](#requirement-apis)). 
+An agency's program [Requirements](#requirements) endpoint contains a number of distinct parts, namely [metadata](#requirement-metadata), [program definitions](#requirement-programs), and [data specs](#requirement-data-specs) (with sub sections on relevant [required APIs](#requirement-apis)).
 
 ```jsonc
 {
   "metadata": {
     // metadata fields per the "Requirement Metadata" section
   },
-  "programs" [ 
+  "programs" [
     {
       "description" : "[PROGRAM DESCRIPTION]",
       "provider_ids": [
@@ -452,24 +466,24 @@ An agency's program [Requirements](#requirements) endpoint contains a number of 
         },
         // other data specs per the "Requirement Data Specs" section
       ]
-    }, 
+    },
     // other MDS versions per the "Requriement MDS Version" section
   }
 }
 ```
 
-| Name                         | Type            | Required / Optional | Description              | 
-| ---------------------------- | --------------- | -------- | ----------------------------------- | 
-| `metadata`                   | Array           | Required | Array of [Requirement Metadata](#requirement-metadata) fields. | 
-| `programs`                   | Array           | Required | Array of [Requirement Programs](#requirement-programs) data. | 
-| `required_data_specs`        | Array           | Required | Array of [Requirement Data Specs](#requirement-data-specs) data. | 
-| `required_apis`              | Array           | Required | Array of [Requirement APIs](#requirement-apis) data. | 
+| Name                         | Type            | Required / Optional | Description              |
+| ---------------------------- | --------------- | -------- | ----------------------------------- |
+| `metadata`                   | Array           | Required | Array of [Requirement Metadata](#requirement-metadata) fields. |
+| `programs`                   | Array           | Required | Array of [Requirement Programs](#requirement-programs) data. |
+| `required_data_specs`        | Array           | Required | Array of [Requirement Data Specs](#requirement-data-specs) data. |
+| `required_apis`              | Array           | Required | Array of [Requirement APIs](#requirement-apis) data. |
 
 [Top][toc]
 
 #### Requirement Metadata
 
-Contains metadata applicable to the agency and at the top of its [Requirement](#requirement) data feed in the `metadata` section. 
+Contains metadata applicable to the agency and at the top of its [Requirement](#requirement) data feed in the `metadata` section.
 
 ```jsonc
 {
@@ -486,7 +500,7 @@ Contains metadata applicable to the agency and at the top of its [Requirement](#
     "agency_website_url": "[URL]"
     "url": "[URL]"
   },
-  "mds_versions" [ 
+  "mds_versions" [
     // Requirement MDS Versions
   ]
 }
@@ -510,12 +524,12 @@ Contains metadata applicable to the agency and at the top of its [Requirement](#
 
 #### Requirement Programs
 
-Contains information about an agency's programs, with links to policy documents, and a list of providers and data specs/APIs/endpoints/fields that the program applies to over a certain time frame in its [Requirement](#requirement) data feed in the `required_data_specs` section. 
+Contains information about an agency's programs, with links to policy documents, and a list of providers and data specs/APIs/endpoints/fields that the program applies to over a certain time frame in its [Requirement](#requirement) data feed in the `required_data_specs` section.
 
-Unique combinations for data specs, specific providers, vehicle types, policies, and dates (past, current, or future) can be defined. For example an agency can define MDS version 1.2.0 and GBFS 2.2 for Provider #1 in a pilot with beta endpoints and optional fields, MDS version 1.2.0 for other providers without beta features starting a month from now, and MDS version 1.1.0 for Provider #2 with docked bikeshare. 
+Unique combinations for data specs, specific providers, vehicle types, policies, and dates (past, current, or future) can be defined. For example an agency can define MDS version 1.2.0 and GBFS 2.2 for Provider #1 in a pilot with beta endpoints and optional fields, MDS version 1.2.0 for other providers without beta features starting a month from now, and MDS version 1.1.0 for Provider #2 with docked bikeshare.
 
 ```jsonc
-// ...  
+// ...
   "programs": [
     {
       "description" : "[PROGRAM DESCRIPTION]",
@@ -542,15 +556,15 @@ Unique combinations for data specs, specific providers, vehicle types, policies,
 // ...
 ```
 
-| Name                         | Type            | Required / Optional | Description              | 
-| ---------------------------- | --------------- | -------- | ----------------------------------- | 
-| `description`                | text            | Required | Simple agency program description of this combination of MDS, providers, vehicles, and time frame. | 
+| Name                         | Type            | Required / Optional | Description              |
+| ---------------------------- | --------------- | -------- | ----------------------------------- |
+| `description`                | text            | Required | Simple agency program description of this combination of MDS, providers, vehicles, and time frame. |
 | `program_website_url`        | URL             | Required | URL of the agency's transportation policy page. E.g. "https://www.cityname.gov/transportation/shared-devices.htm" |
 | `program_document_url`        | URL             | Optional | URL of the agency's operating permit rules that mention data requirements. E.g. "https://www.cityname.gov/mds_data_policy.pdf" |
-| `provider_ids`               | UUID[]          | Required | Array of provider UUIDs that apply to this group the requirements | 
-| `vehicle_type`               | Enum            | Optional | Array of [Vehicle Types](../general-information.md#vehicle-types) that apply to this requirement. If absent it applies to all vehicle types. | 
-| `start_date`                 | [timestamp][ts] | Required | Beginning date/time of requirements | 
-| `end_date`                   | [timestamp][ts] | Required | End date/time of requirements. Can be null. Keep data at least one year past `end_date` before removing. | 
+| `provider_ids`               | UUID[]          | Required | Array of provider UUIDs that apply to this group the requirements |
+| `vehicle_type`               | Enum            | Optional | Array of [Vehicle Types](../general-information.md#vehicle-types) that apply to this requirement. If absent it applies to all vehicle types. |
+| `start_date`                 | [timestamp][ts] | Required | Beginning date/time of requirements |
+| `end_date`                   | [timestamp][ts] | Required | End date/time of requirements. Can be null. Keep data at least one year past `end_date` before removing. |
 | `required_data_specs`        | Array           | Required | Array of required [Data Specs](#requirement-data-specs) |
 
 [Top][toc]
@@ -560,7 +574,7 @@ Unique combinations for data specs, specific providers, vehicle types, policies,
 For each combination of items in a program, you can specify the data specs, APIs, endpoints, and optional fields that are required per your agency's program policies. This is an array within the [Requirement MDS Versions](#requirement-mds-versions) `mds_apis` section in the [Requirement](#requirement) data feed.
 
 ```jsonc
-// ...  
+// ...
       "required_data_specs": [
         {
           "data_spec_name": "[DATA SPEC NAME]",
@@ -581,12 +595,12 @@ For each combination of items in a program, you can specify the data specs, APIs
 // ...
 ```
 
-| Name                 | Type   | Required / Optional | Description              | 
-| -------------------- | ------ | -------- | ----------------------------------- | 
-| `data_spec_name`     | Enum   | Required | Name of the data spec required. Supported values are: '[MDS](https://github.com/openmobilityfoundation/mobility-data-specification/tree/ms-requirements)', '[GBFS](https://github.com/NABSA/gbfs/tree/v2.2)'. Others like GOFS, GTFS, TOMP-API, etc can be tested by agencies and officially standardized here in the future -- leave your feedback on [this issue](https://github.com/openmobilityfoundation/mobility-data-specification/issues/682). | 
-| `version`            | Text   | Required | Version number of the data spec required. E.g. '1.2.0' | 
-| `required_apis`      | Array  | Conditionally Required | Name of the [Requirement APIs](#requirement-apis) that need to be served by providers. At least one API is required. APIs not listed will not be available to the agency. | 
-| `available_apis`     | Array  | Conditionally Required | Name of the [Requirement APIs](#requirement-apis) that are being served by agencies.  Not applicable to GBFS. APIs not listed will not be available to the provider. | 
+| Name                 | Type   | Required / Optional | Description              |
+| -------------------- | ------ | -------- | ----------------------------------- |
+| `data_spec_name`     | Enum   | Required | Name of the data spec required. Supported values are: '[MDS](https://github.com/openmobilityfoundation/mobility-data-specification/tree/ms-requirements)', '[GBFS](https://github.com/NABSA/gbfs/tree/v2.2)'. Others like GOFS, GTFS, TOMP-API, etc can be tested by agencies and officially standardized here in the future -- leave your feedback on [this issue](https://github.com/openmobilityfoundation/mobility-data-specification/issues/682). |
+| `version`            | Text   | Required | Version number of the data spec required. E.g. '1.2.0' |
+| `required_apis`      | Array  | Conditionally Required | Name of the [Requirement APIs](#requirement-apis) that need to be served by providers. At least one API is required. APIs not listed will not be available to the agency. |
+| `available_apis`     | Array  | Conditionally Required | Name of the [Requirement APIs](#requirement-apis) that are being served by agencies.  Not applicable to GBFS. APIs not listed will not be available to the provider. |
 
 [Top][toc]
 
@@ -601,11 +615,11 @@ An agency may require providers to serve optional APIs, endpoints, and fields th
 You may also show which APIs, endpoints, and fields your agency is serving to providers and the public. This is an `available_apis` array within the [Requirement Data Specs](#requirement-data-specs) section in the [Requirement](#requirement) data feed.
 
 ```jsonc
-// ...  
+// ...
           "required_apis": [
             {
               "api_name" : "[API NAME]",
-              "required_endpoints": [ 
+              "required_endpoints": [
                 {
                   "endpoint_name" : "[ENDPOINT NAME]",
                   "required_fields": [
@@ -625,7 +639,7 @@ You may also show which APIs, endpoints, and fields your agency is serving to pr
           "available_apis": [
             {
               "api_name" : "[API NAME]",
-              "available_endpoints": [ 
+              "available_endpoints": [
                 {
                   "endpoint_name" : "[ENDPOINT NAME]",
                   "url": "[ENDPOINT URL]",
@@ -641,28 +655,28 @@ You may also show which APIs, endpoints, and fields your agency is serving to pr
 // ...
 ```
 
-| Name                 | Type  | Required/Optional | Description                | 
-| -------------------- | ----- | -------- | ----------------------------------- | 
-| `api_name`           | Text  | Required | Name of the applicable API required. At least one API is required. APIs not listed will not be available to the agency. E.g. for MDS: 'provider', or 'agency'. For GBFS, this field is omitted since GBFS starts at the `endpoint` level. | 
-| `endpoint_name`      | Text  | Required | Name of the required endpoint under the API. At least one endpoint is required. E.g. for MDS 'provider': 'trips' | 
+| Name                 | Type  | Required/Optional | Description                |
+| -------------------- | ----- | -------- | ----------------------------------- |
+| `api_name`           | Text  | Required | Name of the applicable API required. At least one API is required. APIs not listed will not be available to the agency. E.g. for MDS: 'provider', or 'agency'. For GBFS, this field is omitted since GBFS starts at the `endpoint` level. |
+| `endpoint_name`      | Text  | Required | Name of the required endpoint under the API. At least one endpoint is required. E.g. for MDS 'provider': 'trips' |
 
-**Provider Endpoints** - Specific to the `required_apis` array 
+**Provider Endpoints** - Specific to the `required_apis` array
 
-| Name                 | Type  | Required/Optional | Description                | 
-| -------------------- | ----- | -------- | ----------------------------------- | 
-| `required_endpoints` | Array | Required | Array of optional endpoints required by the agency. At least one is required. Endpoints not listed will not be available to the agency. | 
-| `required_fields`    | Array | Optional | Array of optional field names required by the agency. Can be omitted if no optional fields are required. Use dot notation for nested fields. See **special notes** below. | 
-| `disallowed_fields`  | Array | Optional | Array of optional field names which must not be returned by in the endpoint, even if required in MDS. Use dot notation for nested fields. See **special notes** below. | 
+| Name                 | Type  | Required/Optional | Description                |
+| -------------------- | ----- | -------- | ----------------------------------- |
+| `required_endpoints` | Array | Required | Array of optional endpoints required by the agency. At least one is required. Endpoints not listed will not be available to the agency. |
+| `required_fields`    | Array | Optional | Array of optional field names required by the agency. Can be omitted if no optional fields are required. Use dot notation for nested fields. See **special notes** below. |
+| `disallowed_fields`  | Array | Optional | Array of optional field names which must not be returned by in the endpoint, even if required in MDS. Use dot notation for nested fields. See **special notes** below. |
 
-**Agency Endpoints** - Specific to the `available_apis` array 
+**Agency Endpoints** - Specific to the `available_apis` array
 
-| Name                 | Type  | Required/Optional | Description                | 
-| -------------------- | ----- | -------- | ----------------------------------- | 
-| `available_endpoints`| Array | Required | Array of endpoints provided by the agency. At least one is required. Endpoints not listed will not be available to the provider. | 
-| `url`                | URL   | Optional | Location of API endpoint url. Required if the API is unauthenticated and public, optional if endpoint is authenticated and private. E.g. "https://mds.cityname.gov/geographies/geography/1.1.0"  | 
-| `available_fields`   | Array | Optional | Array of optional field names provided by the agency. Can be omitted if none are required. Use dot notation for nested fields. See **special notes** below. | 
+| Name                 | Type  | Required/Optional | Description                |
+| -------------------- | ----- | -------- | ----------------------------------- |
+| `available_endpoints`| Array | Required | Array of endpoints provided by the agency. At least one is required. Endpoints not listed will not be available to the provider. |
+| `url`                | URL   | Optional | Location of API endpoint url. Required if the API is unauthenticated and public, optional if endpoint is authenticated and private. E.g. "https://mds.cityname.gov/geographies/geography/1.1.0"  |
+| `available_fields`   | Array | Optional | Array of optional field names provided by the agency. Can be omitted if none are required. Use dot notation for nested fields. See **special notes** below. |
 
-**Special notes about `required_fields` and `disallowed_fields`.** 
+**Special notes about `required_fields` and `disallowed_fields`.**
 
 - All fields marked 'Required' in MDS are still included by default and should not be enumerated in `required_fields`. They are not affected by the Requirements endpoint, unless explicitly listed in `disallowed_fields`.
 - Fields in MDS marked 'Required if available' are still returned if available, and are not affected by the Requirements endpoint, unless explicitly listed in `disallowed_fields`.

--- a/policy/examples/README.md
+++ b/policy/examples/README.md
@@ -274,7 +274,7 @@ File: [`per-trip-fees.json`](per-trip-fees.json)
       "rule_type": "rate",
       "rule_units": "amount",
       "rate_amount": 25,
-      "rate_recurrence": "once",
+      "rate_recurrence": "once_on_match",
       "geographies": [
         "b4bcc213-4888-48ce-a33d-4dd6c3384bda"
       ],
@@ -457,7 +457,8 @@ This policy states parking fees as such:
 
 For example, say a vehicle is parked for 6.5 hours. It will be charged `$2 (0-1hr) + $4 (1-2hr) + $10 (2-3hr) + $10 (3-4hr) + $10 (4-5hr) + $10 (5-6hr) + $10 (6-6.5hr) = $56`
 File: [`tiered-parking-fees-per-hour.json`](tiered-parking-fees-per-hour.json)
-```
+
+```json
 {
   "name": "Tiered Dwell Time Example",
   "description": "First hour $2, second hour $4, every hour onwards $10",
@@ -506,7 +507,7 @@ File: [`tiered-parking-fees-per-hour.json`](tiered-parking-fees-per-hour.json)
       "rate_recurrence": "each_time_unit"
     }
   ]
-}  
+}
 ```
 
 ## Tiered Parking Fees Total
@@ -517,7 +518,8 @@ This policy states parking fees as such:
 
 For example, if a vehicle is parked for 6.5 hours, it will be charged $10 on exit.
 File: [`tiered-parking-fees-total.json`](tiered-parking-fees-total.json)
-```
+
+```json
 {
   "name": "Tiered Dwell Time Example",
   "description": "If parked for <1hr $2 upon exit, if parked for 1-2 hours $4 upon exit, if parked for longer than 2 hours $10 upon exit",
@@ -568,5 +570,5 @@ File: [`tiered-parking-fees-total.json`](tiered-parking-fees-total.json)
   ]
 }
 ```
-[Top](#table-of-contents)
 
+[Top](#table-of-contents)

--- a/policy/examples/README.md
+++ b/policy/examples/README.md
@@ -456,6 +456,16 @@ This policy states parking fees as such:
 - Parking every hour onwards costs $10
 
 For example, say a vehicle is parked for 6.5 hours. It will be charged `$2 (0-1hr) + $4 (1-2hr) + $10 (2-3hr) + $10 (3-4hr) + $10 (4-5hr) + $10 (5-6hr) + $10 (6-6.5hr) = $56`
+
+This policy may be specified different ways using the `rate_applies_when` field.
+Both examples are shown here.
+
+### With default `rate_applies_when = "out_of_bounds"`
+
+By default the `rate_applies_when` field has the value `out_of_bounds`,
+meaning the rate should take effect when an event is outside the bounds
+of a rule's `minimum` and `maximum` values.
+
 File: [`tiered-parking-fees-per-hour.json`](tiered-parking-fees-per-hour.json)
 
 ```json
@@ -504,6 +514,75 @@ File: [`tiered-parking-fees-per-hour.json`](tiered-parking-fees-per-hour.json)
       "vehicle_types": ["bicycle", "scooter"],
       "maximum": 0,
       "rate_amount": 200,
+      "rate_recurrence": "each_time_unit"
+    }
+  ]
+}
+```
+
+### With `rate_applies_when = "in_bounds"`
+
+When the `rate_applies_when` field has the value `in_bounds`,
+the rate takes effect when an event is within a rule's `minimum` and
+`maximum` values. Note that this also uses the `inclusive_minimum` and
+`inclusive_maximum` fields to create non-overlapping ranges for the rules.
+
+File: [`tiered-parking-fees-per-hour-in-bounds.json`](tiered-parking-fees-per-hour-in-bounds.json)
+
+```json
+{
+  "name": "Tiered Dwell Time Example",
+  "description": "First hour $2, second hour $4, every hour onwards $10",
+  "policy_id": "2800cd0a-7827-4110-9713-b9e5bf29e9a1",
+  "start_date": 1558389669540,
+  "publish_date": 1558389669540,
+  "end_date": null,
+  "prev_policies": null,
+  "provider_ids": [],
+  "currency": "USD",
+  "rules": [
+    {
+      "name": "0-1 Hour",
+      "rule_id": "6b6fe61b-dbe5-4367-8e35-84fb14d23c54",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "maximum": 1,
+      "inclusive_maximum": false,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 200,
+      "rate_recurrence": "each_time_unit"
+    },
+    {
+      "name": "1-2 Hours",
+      "rule_id": "edd6a195-bb30-4eb5-a2cc-44e5a18798a2",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "minimum": 1,
+      "maximum": 2,
+      "inclusive_minimum": true,
+      "inclusive_maximum": false,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 400,
+      "rate_recurrence": "each_time_unit"
+    },
+    {
+      "name": "> 2 hours",
+      "rule_id": "9cd1768c-ab9e-484c-93f8-72a7078aa7b9",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "minimum": 2,
+      "inclusive_minimum": true,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 1000,
       "rate_recurrence": "each_time_unit"
     }
   ]

--- a/policy/examples/tiered-parking-fees-per-hour-in-bounds.json
+++ b/policy/examples/tiered-parking-fees-per-hour-in-bounds.json
@@ -1,0 +1,57 @@
+{
+  "name": "Tiered Dwell Time Example",
+  "description": "First hour $2, second hour $4, every hour onwards $10",
+  "policy_id": "2800cd0a-7827-4110-9713-b9e5bf29e9a1",
+  "start_date": 1558389669540,
+  "publish_date": 1558389669540,
+  "end_date": null,
+  "prev_policies": null,
+  "provider_ids": [],
+  "currency": "USD",
+  "rules": [
+    {
+      "name": "0-1 Hour",
+      "rule_id": "6b6fe61b-dbe5-4367-8e35-84fb14d23c54",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "maximum": 1,
+      "inclusive_maximum": false,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 200,
+      "rate_recurrence": "each_time_unit"
+    },
+    {
+      "name": "1-2 Hours",
+      "rule_id": "edd6a195-bb30-4eb5-a2cc-44e5a18798a2",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "minimum": 1,
+      "maximum": 2,
+      "inclusive_minimum": true,
+      "inclusive_maximum": false,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 400,
+      "rate_recurrence": "each_time_unit"
+    },
+    {
+      "name": "> 2 hours",
+      "rule_id": "9cd1768c-ab9e-484c-93f8-72a7078aa7b9",
+      "rule_type": "time",
+      "rule_units": "hours",
+      "geographies": ["0c77c813-bece-4e8a-84fd-f99af777d198"],
+      "statuses": { "available": [], "non_operational": [] },
+      "vehicle_types": ["bicycle", "scooter"],
+      "minimum": 2,
+      "inclusive_minimum": true,
+      "rate_applies_when": "in_bounds",
+      "rate_amount": 1000,
+      "rate_recurrence": "each_time_unit"
+    }
+  ]
+}

--- a/policy/policy.json
+++ b/policy/policy.json
@@ -190,11 +190,24 @@
             "string",
             "null"
           ],
-          "description": "Specify when a rate is applied \u00e2\u20ac\u201c either once, or periodically according to a time unit specified using rule_units",
+          "description": "Specify how a rate is applied \u00e2\u20ac\u201c either once, or periodically according to a time unit specified using rule_units",
           "enum": [
-            "once",
+            "once_on_match",
+            "once_on_unmatch",
             "each_time_unit",
             "per_complete_time_unit"
+          ]
+        },
+        "rate_applies_when": {
+          "$id": "#/definitions/rule/properties/rate_applies_when",
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Specify when a rate is applicable to an event or count: when it's within rule bounds or when it is not",
+          "enum": [
+            "in_bounds",
+            "out_of_bounds"
           ]
         },
         "start_time": {

--- a/schema/templates/policy/policy.json
+++ b/schema/templates/policy/policy.json
@@ -179,11 +179,21 @@
         "rate_recurrence": {
           "$id": "#/definitions/rule/properties/rate_recurrence",
           "type": ["string", "null"],
-          "description": "Specify when a rate is applied – either once, or periodically according to a time unit specified using rule_units",
+          "description": "Specify how a rate is applied – either once, or periodically according to a time unit specified using rule_units",
           "enum": [
-            "once",
+            "once_on_match",
+            "once_on_unmatch",
             "each_time_unit",
             "per_complete_time_unit"
+          ]
+        },
+        "rate_applies_when": {
+          "$id": "#/definitions/rule/properties/rate_applies_when",
+          "type": ["string", "null"],
+          "description": "Specify when a rate is applicable to an event or count: when it's within rule bounds or when it is not",
+          "enum": [
+            "in_bounds",
+            "out_of_bounds"
           ]
         },
         "start_time": {


### PR DESCRIPTION
## Explain pull request

This is implementing my proposal from #666. The `rate_applies_when` field allows people constructing policy rules with attached rates to specify when the rate is applicable: is it when something is within the rule bounds or when it is outside of them? The `rate_applies_when` when field may take on the values `in_bounds` and `out_of_bounds`. It is used in conjunction with the rule `minimum` and `maximum` fields. It defaults to `out_of_bounds`.

I also used this PR to bring the Policy JSON schema and an example policy up-to-date following the merger of #658.

## Is this a breaking change

* I'm not sure

This field is optional so it doesn't break in that sense, but having a defined notion of when rates apply could change the interpretation of existing policies.

## Impacted Spec

* `policy`

## Additional context

The MDS policy spec does not currently specify when rates apply. In #658 @avatarneil argued that they apply when an event falls _outside_ the rule bounds, but in the `rate` rule examples in the [example policies](https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/policy/examples/README.md) the rates are applying to events/counts _within_ the rule bounds. With the merger of #658 we now have example rules that are not consistent in their interpretation of when rates apply. (The example rate policies do not specify `minimum` or `maximum` fields, so the are implicitly 0 and infinity, respectively, though perhaps it could be argued that `minimum` and `maximum` are not applicable to rate type rules.)

See also my proposal in #666.