### PR TITLE
Align Policy JSON Schema & Examples with spec

### DIFF
--- a/policy/examples/idle-time.json
+++ b/policy/examples/idle-time.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "a2c9a65f-fd85-463e-9564-fc95ea473f7d",
         "name": "Idle Times",

--- a/policy/examples/metered-parking-fees.json
+++ b/policy/examples/metered-parking-fees.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "6a3dd008-836a-11ea-bc55-0242ac130003",
         "published_date": 1586736000000,

--- a/policy/examples/per-trip-fees.json
+++ b/policy/examples/per-trip-fees.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "d2567b3c-3071-48a6-bbeb-3424721dbd12",
         "published_date": 1586736000000,

--- a/policy/examples/prohibited-zone.json
+++ b/policy/examples/prohibited-zone.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "39a653be-7180-4188-b1a6-cae33c280341",
         "name": "Prohibited Dockless Zones",

--- a/policy/examples/provider-cap.json
+++ b/policy/examples/provider-cap.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "name": "Test City Mobility Caps: Company X",
         "description": "Mobility caps as described in the One-Year Permit",

--- a/policy/examples/required-parking.json
+++ b/policy/examples/required-parking.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "99f7a469-6e3a-4981-9313-c2f6c0bbd5ce",
         "name": "Test City Mobility Hubs",

--- a/policy/examples/speed-limits.json
+++ b/policy/examples/speed-limits.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "95645117-fd85-463e-a2c9-fc95ea47463e",
         "name": "Speed Limits",

--- a/policy/examples/tiered-parking-fees-per-hour.json
+++ b/policy/examples/tiered-parking-fees-per-hour.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.2.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "name": "Tiered Dwell Time Example",
         "description": "First hour $2, second hour $4, every hour onwards $10",

--- a/policy/examples/tiered-parking-fees-total.json
+++ b/policy/examples/tiered-parking-fees-total.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.2.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "name": "Tiered Dwell Time Example",
         "description": "If parked for <1hr $2 upon exit, if parked for 1-2 hours $4 upon exit, if parked for longer than 2 hours $10 upon exit",

--- a/policy/examples/vehicle-row-fees.json
+++ b/policy/examples/vehicle-row-fees.json
@@ -2,7 +2,7 @@
   "updated": 0,
   "version": "1.0.0",
   "data": {
-    "policy": [
+    "policies": [
       {
         "policy_id": "4137a47c-836a-11ea-bc55-0242ac130003",
         "published_date": 1586736000000,

--- a/schema/templates/policy/policy.json
+++ b/schema/templates/policy/policy.json
@@ -319,7 +319,7 @@
         "policy"
       ],
       "properties": {
-        "policy": {
+        "policies": {
           "$id": "#/properties/data/properties/policy",
           "type": "array",
           "title": "The policy payload",


### PR DESCRIPTION
## Explain pull request

This PR is to resolve #599, which highlighted inconsistencies between the spec and JSONSchema definitions & examples. The approach taken was to leave the spec as-is (for now) in order to be non-breaking, and to update the JSONSchema definitions & examples to align with the spec in its current state.

## Is this a breaking change

* No, not breaking

## Impacted Spec

* `policy`

## Additional context

For MDS 2.0, we may want to explore structuring this in accordance with the JSONAPI spec, e.g.
```
{
  "data": {
    "type": "policies",
    "attributes": {
     }
  }
},
```
