### PR TITLE
Add Scoot and Revel to providers.csv

### DIFF
--- a/providers.csv
+++ b/providers.csv
@@ -40,5 +40,5 @@ Helbiz,3aece8c6-416a-4d39-bcc4-d02524cb8004,https://helbiz.com,https://mds.helbi
 Kiwibot,5f19acae-d7e9-4b57-96bd-f6406712d654,https://www.kiwibot.com/,,
 Yego,da99028e-28b7-4dd3-ad23-41b7a045db8a,https://www.rideyego.com/,https://mds.yego.app/mds,https://services.rideyego.com/gbfs
 Leo&Go,84b174c4-eb74-5d07-bdeb-27f4215d2aa9,https://www.leoandgo.com,https://mds.vulog.io/mds/fleets/LEONGO-FRLIO,
-Scoot, 07a25fe6-d0be-11e8-a8d5-f2801f1b9fd1, https://scoot.co/san-francisco/,https://mds.bird.co/,https://mds.bird.co/gbfs/
-Revel, 89301314-1210-4126-a213-3c41423f2ac5, https://gorevel.com/,https://opendata.gorevel.com/opendata/mds/,https://gbfs.gorevel.com/gbfs/v2/
+Scoot,07a25fe6-d0be-11e8-a8d5-f2801f1b9fd1,https://scoot.co/san-francisco/,https://mds.bird.co/,https://mds.bird.co/gbfs/
+Revel,89301314-1210-4126-a213-3c41423f2ac5,https://gorevel.com/,https://opendata.gorevel.com/opendata/mds/,https://gbfs.gorevel.com/gbfs/v2/

--- a/providers.csv
+++ b/providers.csv
@@ -31,3 +31,5 @@ Pony,f190d330-b49e-4590-871b-0bcbec565a8c,https://getapony.com/,https://mds.geta
 SHARE-NOW,d8f880d6-96d8-4cdc-8069-32a683b2bce6,https://www.share-now.com,https://external.share-now.com/api/rental/mds/,https://external.share-now.com/api/rental/mds/gbfs/
 Boaz Bikes,7c96bc58-fb63-433a-b77f-84ccb1c9d737,https://www.boazbikes.com/,https://mds.movatic.co/,https://gbsf.movatic.co/en/1.1/576347857979998215
 VeoRide INC.,6e39f9db-751b-5cea-ae7e-486f579a56bc,https://www.veoride.com/,https://cluster-prod.veoride.com/api/shares/mds,https://cluster-prod.veoride.com/api/shares/gbfs
+Scoot, 07a25fe6-d0be-11e8-a8d5-f2801f1b9fd1, https://scoot.co/san-francisco/,,
+Revel, 89301314-1210-4126-a213-3c41423f2ac5, https://gorevel.com/,,

--- a/providers.csv
+++ b/providers.csv
@@ -40,5 +40,5 @@ Helbiz,3aece8c6-416a-4d39-bcc4-d02524cb8004,https://helbiz.com,https://mds.helbi
 Kiwibot,5f19acae-d7e9-4b57-96bd-f6406712d654,https://www.kiwibot.com/,,
 Yego,da99028e-28b7-4dd3-ad23-41b7a045db8a,https://www.rideyego.com/,https://mds.yego.app/mds,https://services.rideyego.com/gbfs
 Leo&Go,84b174c4-eb74-5d07-bdeb-27f4215d2aa9,https://www.leoandgo.com,https://mds.vulog.io/mds/fleets/LEONGO-FRLIO,
-Scoot, 07a25fe6-d0be-11e8-a8d5-f2801f1b9fd1, https://scoot.co/san-francisco/,,
-Revel, 89301314-1210-4126-a213-3c41423f2ac5, https://gorevel.com/,,
+Scoot, 07a25fe6-d0be-11e8-a8d5-f2801f1b9fd1, https://scoot.co/san-francisco/,https://mds.bird.co/,https://mds.bird.co/gbfs/
+Revel, 89301314-1210-4126-a213-3c41423f2ac5, https://gorevel.com/,https://opendata.gorevel.com/opendata/mds/,https://gbfs.gorevel.com/gbfs/v2/


### PR DESCRIPTION
## Explain pull request

Add Scoot and Revel provider_id values to providers.csv.  Scoot and Revel have been operating scooters and mopeds, respectively in San Francisco for a few years using these values for provider_id.

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

None - providers.csv file
