### PR TITLE
Define a "trip" for the purposes of analyses

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -22,6 +22,7 @@ This document contains specifications that are shared between the various MDS [A
   - [GBFS Compatibility](#gbfs-compatibility)
 - [Timestamps](#timestamps)
 - [UUIDs](#uuids)
+- [Trips](#trips)
 - [Vehicle Characteristics](#vehicle-characteristics)
   - [Accessibility Options](#accessibility-options)
   - [Propulsion Types](#propulsion-types)
@@ -144,9 +145,9 @@ For the purposes of this specification, the intersection of two geographic datat
 
 ## Geography-Driven Events
 
-**[Beta feature](/general-information.md#beta-features):** *Yes (as of 1.1.0)*. [Leave feedback](https://github.com/openmobilityfoundation/mobility-data-specification/issues/670)  
+**[Beta feature](/general-information.md#beta-features):** *Yes (as of 1.1.0)*. [Leave feedback](https://github.com/openmobilityfoundation/mobility-data-specification/issues/670)
 
-Geography-Driven Events (GDE) is a new MDS feature for Agencies to perform complete Policy compliance monitoring without precise location data. Geography-Driven Events describe individual vehicles in realtime – not just aggregate data. However, rather than receiving the exact location of a vehicle, Agencies receive information about the vehicle's current geographic region. The regions used for Geography-Driven Events correspond to the Geographies in an Agency's current Policy. In this way, the data-shared using Geography-Driven Events is matched to an Agency's particular regulatory needs. 
+Geography-Driven Events (GDE) is a new MDS feature for Agencies to perform complete Policy compliance monitoring without precise location data. Geography-Driven Events describe individual vehicles in realtime – not just aggregate data. However, rather than receiving the exact location of a vehicle, Agencies receive information about the vehicle's current geographic region. The regions used for Geography-Driven Events correspond to the Geographies in an Agency's current Policy. In this way, the data-shared using Geography-Driven Events is matched to an Agency's particular regulatory needs.
 
 See [this example](/policy/examples/requirements.md#geography-driven-events) for how to implement GDE using [Policy Requirements](/policy#requirement).
 
@@ -164,7 +165,7 @@ Here's how it works in practice:
 
 	*Agency adds rule disallowing parking on waterfront path, begins receiving data on events within area.*
 
-Agencies that wish to use Geography-Driven Events do so by requiring a new `event_geographies` field in status events. When an Agency is using Geography-Driven Events, Providers must emit a new `changed_geographies` status event whenever a vehicle in a trip enters or leaves a Geography managed by a Policy. 
+Agencies that wish to use Geography-Driven Events do so by requiring a new `event_geographies` field in status events. When an Agency is using Geography-Driven Events, Providers must emit a new `changed_geographies` status event whenever a vehicle in a trip enters or leaves a Geography managed by a Policy.
 
 During the Beta period for this feature, location and telemetry data remain required fields. This allows Agencies to test Geography-Driven Events, measuring its accuracy and efficacy against regulatory systems based on precise location data. After the beta period, if Geography-Driven Events is deemed by the OMF to be accurate and effective, the specification will evolve to allow cities to use Geography-Driven Events in lieu of location or telemetry data.
 
@@ -280,6 +281,23 @@ A `timestamp` refers to integer milliseconds since Unix epoch.
 Object identifiers are described via Universally Unique Identifiers [(UUIDs)](https://en.wikipedia.org/wiki/Universally_unique_identifier). For example, the `device_id` field used to uniquely identify a vehicle is a UUID.
 
 MDS uses Version 1 UUIDs by default. Version 4 UUIDs may be used where noted.
+
+[Top][toc]
+
+## Trips
+
+Counting trips is a common analysis with MDS data, but in some instances when
+a user rents a vehicle the rental may end up being very short because the
+vehicle is unusable or because the customer changes their mind.
+To facilitate a common definition of trips for analysis, MDS defines a trip
+as a user taking control of a vehicle for 60 seconds or more.
+If a user reserves a vehicle and cancels before taking control of the vehicle
+that reservation does not count as a trip, nor does a user taking control of
+the vehicle and canceling or ending the trip in under 60 seconds.
+
+Providers are still expected to report all trips and trip related events in
+all MDS endpoints, but parties may use this definition as a shared reference
+at the recommendation of the MDS community when analysing trips.
 
 [Top][toc]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -147,7 +147,8 @@ For Timestamps, Vehicle Types, Propulsion Types, UUIDs, Costs, and Currencies, r
 
 ## Trips
 
-A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.
+A [trip][trips-general-info] represents a journey taken by a *mobility as a service* customer with
+a geo-tagged start and stop point.
 
 The trips endpoint allows a user to query historical trip data.
 
@@ -635,6 +636,7 @@ In addition to the standard [Provider payload wrapper](#response-format), respon
 [stops-schema]: stops.json
 [toc]: #table-of-contents
 [trips]: #trips
+[trips-general-info]: /general-information.md#stop-based-geographic-data
 [trips-schema]: trips.json
 [ts]: /general-information.md#timestamps
 [vehicles]: #vehicles


### PR DESCRIPTION
## Explain pull request

This addresses #748 by adding a definition of a "trip" to the general-information.md file. The definition is meant for the purposes of analysis in particular, and not for filtering which data points are exchanged as part of MDS endpoints.

I wasn't sure on the exact right spot for this since I hadn't seen anything like this done before in MDS, but I'm open to suggestions on that and the wording of the definition itself.

## Is this a breaking change

* No, not breaking

I don't consider this a breaking change since it doesn't effect the data interchange at all, only downstream analytics, but I might be missing something.

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`
* `policy`
* `provider`

In a way, all of these and none of these. 🤔 
