### PR TITLE
Reports - Add provider_id and adaptive_scooter as a special group type

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -365,6 +365,7 @@ The authenticated reports are monthly, historic flat files that may be pre-gener
 
 | Name               | Type                                      | Comments                                         |
 | ------------------ | ----------------------------------------- | ------------------------------------------------ |
+| provider_id      | UUID                                      | A UUID for the Provider, unique within MDS. See MDS [provider list](/providers.csv). |
 | StartDate          | date                                      | Start date of trip the data row, ISO 8601 format, local timezone |
 | Duration           | string                                    | Value is always `P1M` for monthly. Based on [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) |
 | Special Group Type | [Special Group Type](#special-group-type) | Type that applies to this row                    |

--- a/provider/README.md
+++ b/provider/README.md
@@ -450,6 +450,7 @@ Here are the possible values for the `special_group_type` dimension field:
 | Name       | Description                                                                                                           |	
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |	
 | low_income | Trips where a low income discount is applied by the provider, e.g., a discount from a qualified provider equity plan. |	
+| adaptive_scooter | Trips taken on an adaptive scooter, e.g., scooter with a seat or wider base |
 | all_riders | All riders from any group                                                                                             |	
 
 Other special group types may be added in future MDS releases as relevant agency and provider use cases are identified. When additional special group types or metrics are proposed, a thorough review of utility and relevance in program oversight, evaluation, and policy development should be done by OMF Working Groups, as well as any privacy implications by the OMF Privacy Committee.

--- a/provider/README.md
+++ b/provider/README.md
@@ -365,7 +365,7 @@ The authenticated reports are monthly, historic flat files that may be pre-gener
 
 | Name               | Type                                      | Comments                                         |
 | ------------------ | ----------------------------------------- | ------------------------------------------------ |
-| provider_id      | UUID                                      | A UUID for the Provider, unique within MDS. See MDS [provider list](/providers.csv). |
+| Provider ID        | UUID                                      | A UUID for the Provider, unique within MDS. See MDS provider_id in [provider list](/providers.csv). |
 | StartDate          | date                                      | Start date of trip the data row, ISO 8601 format, local timezone |
 | Duration           | string                                    | Value is always `P1M` for monthly. Based on [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) |
 | Special Group Type | [Special Group Type](#special-group-type) | Type that applies to this row                    |
@@ -386,60 +386,60 @@ All geography IDs included in the city published [Geography](/geography) API end
 
 ### Reports - Example
 
-For 3 months of provider operation in a city (September 2019 through November 2019) for 3 geographies, 2 vehicle types, and 1 special group. Timezone is Eastern Time in the US which is _-4_ from UTC before November 3, 2019, and _-5_ after. Values of `-1` represent [redacted data](#data-redaction) counts.
+For 3 months of a single provider operation in a city (September 2019 through November 2019) for 3 geographies, 2 vehicle types, and 1 special group. Timezone is Eastern Time in the US which is _-4_ from UTC before November 3, 2019, and _-5_ after. Values of `-1` represent [redacted data](#data-redaction) counts.
 
 **September 2019** `/reports/2019-09.csv`
 
 ```csv
-StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
-2019-09-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,1302,983
-2019-09-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,201,104
-2019-09-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,530,200
-2019-09-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,75,26
-2019-09-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,687,450
-2019-09-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,98,45
-2019-09-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,256,104
-2019-09-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,41,16
-2019-09-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,201,140
-2019-09-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,35,21
-2019-09-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,103,39
-2019-09-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,15,-1
+Provider ID,StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,1302,983
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,201,104
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,530,200
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,75,26
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,687,450
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,98,45
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,256,104
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,41,16
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,201,140
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,35,21
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,103,39
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-09-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,15,-1
 ```
 
 **October 2019** `/reports/2019-10.csv`
 
 ```csv
-StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
-2019-10-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,1042,786
-2019-10-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,161,83
-2019-10-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,424,160
-2019-10-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,60,0
-2019-10-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,550,360
-2019-10-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,78,36
-2019-10-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,205,83
-2019-10-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,33,13
-2019-10-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,161,112
-2019-10-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,28,-1
-2019-10-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,82,31
-2019-10-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,-1,0
+Provider ID,StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,1042,786
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,161,83
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,424,160
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,60,0
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,550,360
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,78,36
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,205,83
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,33,13
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,161,112
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,28,-1
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,82,31
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-10-01T00:00-04,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,-1,0
 ```
 
 **November 2019** `/reports/2019-11.csv`
 
 ```csv
-StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
-2019-11-01T00:00-05,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,834,629
-2019-11-01T00:00-05,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,129,66
-2019-11-01T00:00-05,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,339,128
-2019-11-01T00:00-05,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,48,-1
-2019-11-01T00:00-05,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,440,288
-2019-11-01T00:00-05,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,62,29
-2019-11-01T00:00-05,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,164,66
-2019-11-01T00:00-05,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,26,0
-2019-11-01T00:00-05,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,129,90
-2019-11-01T00:00-05,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,22,-1
-2019-11-01T00:00-05,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,-1,25
-2019-11-01T00:00-05,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,0,0
+Provider ID,StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider Count
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,scooter,834,629
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,scooter,129,66
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,339,128
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,44428624-186b-4fc3-a7fb-124f487464a1,bicycle,48,-1
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,440,288
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,scooter,62,29
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,164,66
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,03db06d0-3998-406a-92c7-25a83fc2784a,bicycle,26,0
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,129,90
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,scooter,22,-1
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,all_riders,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,-1,25
+48415839-3e38-4ba5-a557-e45fb4e6a0a3,2019-11-01T00:00-05,P1M,low_income,8ad39dc3-005b-4348-9d61-c830c54c161b,bicycle,0,0
 ```
 
 [Top][toc]
@@ -448,11 +448,11 @@ StartDate,Duration,Special Group Type,Geography ID,Vehicle Type,Trip Count,Rider
 
 Here are the possible values for the `special_group_type` dimension field:	
 
-| Name       | Description                                                                                                           |	
-| ---------- | --------------------------------------------------------------------------------------------------------------------- |	
-| low_income | Trips where a low income discount is applied by the provider, e.g., a discount from a qualified provider equity plan. |	
-| adaptive_scooter | Trips taken on an adaptive scooter, e.g., scooter with a seat or wider base |
-| all_riders | All riders from any group                                                                                             |	
+| Name             | Description                                                                                                           |	
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |	
+| low_income       | Trips where a low income discount is applied by the provider, e.g., a discount from a qualified provider equity plan. |	
+| adaptive_scooter | Trips taken on a scooter with features to improve accessibility for people with disabilities, e.g., scooter with a seat or wider base |
+| all_riders       | All riders from any group                                                                                             |	
 
 Other special group types may be added in future MDS releases as relevant agency and provider use cases are identified. When additional special group types or metrics are proposed, a thorough review of utility and relevance in program oversight, evaluation, and policy development should be done by OMF Working Groups, as well as any privacy implications by the OMF Privacy Committee.
 


### PR DESCRIPTION
## Explain pull request

Following the discussion and [meeting earlier this year](https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-conference-notes,-2022.07.07-(MDS-Working-Group)) on #672, add 'adaptive_scooter' as a special_group_type to reflect SFMTA's use of this in the Reports endpoint for its [scooter program](https://www.sfmta.com/blog/adaptive-scooters-coming-street-near-you).

Also, in our use of Reports, we've found that adding provider_id is necessary so we know which company the report is from.  It would be better if the providers included this directly. 

## Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint).

* Yes, breaking


## Impacted Spec

Which spec(s) will this pull request impact?


* `provider`
