### PR TITLE
Reports - Accept header media-type

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -351,7 +351,7 @@ The list of allowed `vehicle_type` values in MDS. Aligning with [GBFS vehicle ty
 
 MDS APIs must handle requests for specific versions of the specification from clients.
 
-Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.
+Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.  The one exception is the `/reports` endpoint, which returns CSV files instead of JSON, and so uses `application/vnd.mds+csv` as its media-type.  (`csv` is not a [standard media-type suffix](https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xml), but we consider this the least confusing option.)
 
 The version parameter specifies the dot-separated combination of major and minor versions from a published version of the specification. For example, the media-type for version `1.0.1` would be specified as `application/vnd.mds+json;version=1.0`
 

--- a/general-information.md
+++ b/general-information.md
@@ -351,7 +351,7 @@ The list of allowed `vehicle_type` values in MDS. Aligning with [GBFS vehicle ty
 
 MDS APIs must handle requests for specific versions of the specification from clients.
 
-Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.  The one exception is the `/reports` endpoint, which returns CSV files instead of JSON, and so uses `application/vnd.mds+csv` as its media-type.  (`csv` is not a [standard media-type suffix](https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xml), but we consider this the least confusing option.)
+Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.  The one exception is the `/reports` endpoint, which returns CSV files instead of JSON, and so uses `text/vnd.mds+csv` as its media-type.
 
 The version parameter specifies the dot-separated combination of major and minor versions from a published version of the specification. For example, the media-type for version `1.0.1` would be specified as `application/vnd.mds+json;version=1.0`
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -359,7 +359,7 @@ The authenticated reports are monthly, historic flat files that may be pre-gener
 **Endpoint:** `/reports`  
 **Method:** `GET`  
 **[Beta feature][beta]:** Yes (as of 1.1.0). [Leave feedback](https://github.com/openmobilityfoundation/mobility-data-specification/issues/672)  
-**Usage note:** This endpoint uses media-type `application/vnd.mds+csv` instead of `application/vnd.mds+json`, see [Versioning][versioning].
+**Usage note:** This endpoint uses media-type `text/vnd.mds+csv` instead of `application/vnd.mds+json`, see [Versioning][versioning].
 **Schema:** TBD when out of beta  
 **`data` Filename:** monthly file named by year and month, e.g. `/reports/YYYY-MM.csv`  
 **`data` Payload:** monthly CSV files with the following structure: 

--- a/provider/README.md
+++ b/provider/README.md
@@ -359,6 +359,7 @@ The authenticated reports are monthly, historic flat files that may be pre-gener
 **Endpoint:** `/reports`  
 **Method:** `GET`  
 **[Beta feature][beta]:** Yes (as of 1.1.0). [Leave feedback](https://github.com/openmobilityfoundation/mobility-data-specification/issues/672)  
+**Usage note:** This endpoint uses media-type `application/vnd.mds+csv` instead of `application/vnd.mds+json`, see [Versioning][versioning].
 **Schema:** TBD when out of beta  
 **`data` Filename:** monthly file named by year and month, e.g. `/reports/YYYY-MM.csv`  
 **`data` Payload:** monthly CSV files with the following structure: 


### PR DESCRIPTION
## Explain pull request

The spec currently requires the `/reports` endpoint to be queried with media-type `application/vnd.mds+json` in the `Accept` header.  But the endpoint returns a CSV, not JSON, so this is a bit confusing.  This PR suggests a different approach (though it has its own drawback since `csv` is not a standard media-type suffix).

## Is this a breaking change

This is a breaking change.  The intent is for this to be included in MDS 2.0.

## Impacted Spec

Which spec(s) will this pull request impact?

* `provider`

## Additional context

See the discussion from https://github.com/openmobilityfoundation/mobility-data-specification/wiki/Web-conference-notes,-2022.07.07-(MDS-Working-Group) and the discussion at https://github.com/openmobilityfoundation/mobility-data-specification/issues/672
