### PR TITLE
Fix JSON key in /vehicles/status example response

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -247,7 +247,7 @@ If `device_id` is specified, `GET` will return an array with a vehicle status re
 ```json
 {
     "version": "x.y.z",
-    "vehicles": [ ... ]
+    "vehicles_status": [ ... ]
     "links": {
         "first": "https://...",
         "last": "https://...",


### PR DESCRIPTION
# MDS Pull Request

## Explain pull request

The example API response for the /vehicles/status endpoint had the data key as 'vehicles' when it is in fact 'vehicles_status'. See OpenAPI spec [here](https://openmobilityfnd.stoplight.io/docs/mds-openapi/800dc7d0f0420-vehicles-status).

## Is this a breaking change

* No, not breaking. This only brings the documentation in line with the spec.

## Impacted Spec

* `provider`