### PR TITLE
Fix vehicle status payload key

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -240,7 +240,7 @@ In addition to the standard [Provider payload wrapper](#response-format), respon
     "version": "x.y.z",
     "last_updated": "12345",
     "ttl": "12345",
-    "vehicles": []
+    "vehicles_status": []
 }
 ```
 


### PR DESCRIPTION
## Explain pull request

This one example of the /vehicles/status response payload had the wrong payload key, creating confusion for readers.

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `provider`

## Additional context

N/A
